### PR TITLE
Build marketing UI for Alon's application

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,476 @@
-#root {
-  max-width: 1280px;
+.app {
+  padding: clamp(2rem, 4vw, 3rem) clamp(1.5rem, 6vw, 3rem) 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 5vw, 4rem);
+}
+
+.hero {
+  position: relative;
+  width: min(1120px, 100%);
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
+  padding: clamp(2.75rem, 4vw + 2rem, 4.75rem);
+  border-radius: 32px;
+  background: linear-gradient(135deg, #0f172a 0%, #1d4ed8 55%, #60a5fa 100%);
+  color: #f9fbff;
+  overflow: hidden;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.35);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(120% 120% at 90% 0%, rgba(255, 255, 255, 0.22) 0%, transparent 55%),
+    radial-gradient(90% 110% at 0% 100%, rgba(37, 99, 235, 0.35) 0%, transparent 60%);
+  mix-blend-mode: screen;
+  pointer-events: none;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.hero__content {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2.5rem;
+}
+
+.hero__top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+}
+
+.hero__brand {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.hero__logo {
+  width: 60px;
+  height: 60px;
+  border-radius: 18px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(248, 251, 255, 0.2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: #f8fbff;
+  box-shadow: inset 0 0 0 1px rgba(248, 251, 255, 0.12);
+  backdrop-filter: blur(8px);
+}
+
+.hero__company {
+  display: block;
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+.hero__tagline {
+  margin: 0.1rem 0 0;
+  color: rgba(248, 251, 255, 0.75);
+  font-size: 0.95rem;
+}
+
+.hero__contact {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-size: 0.95rem;
+}
+
+.hero__contact a {
+  color: rgba(248, 251, 255, 0.9);
+  background: rgba(15, 23, 42, 0.35);
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+
+.hero__contact a:hover {
+  background: rgba(248, 251, 255, 0.2);
+  transform: translateY(-2px);
+  text-decoration: none;
+}
+
+.hero__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  max-width: 640px;
+}
+
+.hero__pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 1rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.35);
+  color: rgba(248, 251, 255, 0.9);
+  font-weight: 600;
+}
+
+.hero__title {
+  margin: 0;
+  font-size: clamp(2.4rem, 4vw, 3.6rem);
+  line-height: 1.1;
+}
+
+.hero__subtitle {
+  margin: 0;
+  font-size: 1.05rem;
+  color: rgba(248, 251, 255, 0.8);
+}
+
+.hero__actions {
+  display: flex;
+  align-items: center;
+  gap: 1.1rem;
+  flex-wrap: wrap;
+}
+
+.hero__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.65rem;
+  border-radius: 14px;
+  background: #f8fafc;
+  color: #0f172a;
+  font-weight: 600;
+  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.2);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.hero__cta:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.25);
+  text-decoration: none;
+}
+
+.hero__note {
+  color: rgba(248, 251, 255, 0.65);
+  font-size: 0.9rem;
+}
+
+.content {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.75rem, 4vw, 3rem);
+}
+
+.section {
+  background: #ffffff;
+  border-radius: 28px;
+  padding: clamp(2rem, 4vw, 2.9rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(37, 99, 235, 0.08);
+}
+
+.section__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.section__header h2 {
+  margin: 0;
+  font-size: clamp(1.7rem, 2.3vw, 2.2rem);
+  color: #0f172a;
+}
+
+.section__header p {
+  margin: 0;
+  font-size: 1rem;
+  color: #445066;
+}
+
+.workflow {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.workflow__intro h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  color: #102a63;
+}
+
+.workflow__intro p {
+  margin: 0.75rem 0 0;
+  color: #475569;
+}
+
+.workflow__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.workflow__note {
+  margin: 0;
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.step-card {
+  position: relative;
+  border-radius: 20px;
+  padding: 1.75rem;
+  background: linear-gradient(180deg, rgba(37, 99, 235, 0.12) 0%, rgba(37, 99, 235, 0.02) 100%);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  box-shadow: 0 18px 35px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  color: #1f2937;
+}
+
+.step-card__number {
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.05rem;
+  box-shadow: 0 10px 20px rgba(29, 78, 216, 0.35);
+}
+
+.step-card h4 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.step-card p {
+  margin: 0;
+  color: #475569;
+  font-size: 0.98rem;
+}
+
+.step-card--highlight {
+  background: linear-gradient(180deg, rgba(251, 191, 36, 0.2) 0%, rgba(255, 255, 255, 0.95) 100%);
+  border-color: rgba(251, 191, 36, 0.35);
+}
+
+.step-card--highlight .step-card__number {
+  background: #f59e0b;
+  color: #0f172a;
+  box-shadow: 0 10px 22px rgba(245, 158, 11, 0.35);
+}
+
+.workflow__roles {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.25rem;
+}
+
+.stakeholder-card {
+  background: linear-gradient(135deg, #eff3ff 0%, #ffffff 100%);
+  border: 1px solid rgba(37, 99, 235, 0.15);
+  border-radius: 18px;
+  padding: 1.5rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  color: #1f2937;
+}
+
+.stakeholder-card__label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-weight: 700;
+  color: #1d4ed8;
+}
+
+.stakeholder-card h5 {
+  margin: 0;
+  font-size: 1.1rem;
+  color: #0f172a;
+}
+
+.stakeholder-card p {
+  margin: 0;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+.project-lists {
+  display: grid;
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-list li {
+  position: relative;
+  padding: 1rem 1.25rem 1rem 2.9rem;
+  border-radius: 14px;
+  background: linear-gradient(90deg, rgba(37, 99, 235, 0.1) 0%, rgba(37, 99, 235, 0.02) 85%);
+  border: 1px solid rgba(37, 99, 235, 0.12);
+  color: #374151;
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.feature-list li::before {
+  content: '\2713';
+  position: absolute;
+  left: 1.05rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #1d4ed8;
+  color: #ffffff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.85rem;
+  box-shadow: 0 8px 16px rgba(29, 78, 216, 0.3);
+}
+
+.feature-panel {
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.12) 0%, rgba(59, 130, 246, 0.05) 100%);
+  border: 1px solid rgba(37, 99, 235, 0.18);
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.feature-panel h3 {
+  margin: 0;
+  font-size: 1.2rem;
+  color: #0f172a;
+}
+
+.feature-panel ul {
+  margin: 0;
+  padding-left: 1.2rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #1f2937;
+  font-size: 0.98rem;
+}
+
+.feature-panel li::marker {
+  color: #1d4ed8;
+}
+
+.section--process .section__header p {
+  max-width: 720px;
+}
+
+.process-timeline {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.process-timeline__item {
+  position: relative;
+  padding: 1.75rem 1.5rem 1.75rem 3.75rem;
+  border-radius: 18px;
+  background: #f8fafc;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+  color: #1f2937;
+}
+
+.process-timeline__item p {
+  margin: 0;
+}
+
+.process-timeline__badge {
+  position: absolute;
+  left: 1.25rem;
+  top: 1.5rem;
+  width: 32px;
+  height: 32px;
+  border-radius: 10px;
+  background: #1d4ed8;
+  color: #ffffff;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 8px 16px rgba(29, 78, 216, 0.35);
+}
+
+@media (min-width: 960px) {
+  .project-lists {
+    grid-template-columns: 1.4fr 1fr;
   }
-  to {
-    transform: rotate(360deg);
+}
+
+@media (max-width: 768px) {
+  .app {
+    padding: 1.75rem 1.1rem 3rem;
+  }
+
+  .hero {
+    border-radius: 24px;
+    padding: 2.5rem 1.75rem;
+  }
+
+  .hero__actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .hero__cta {
+    width: 100%;
+  }
+
+  .process-timeline__item {
+    padding-left: 3.2rem;
+  }
+
+  .process-timeline__badge {
+    left: 1rem;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
   }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,198 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 
-function App() {
-  const [count, setCount] = useState(0)
+type WorkflowStep = {
+  id: number
+  title: string
+  description: string
+  highlight?: boolean
+}
 
+type Stakeholder = {
+  name: string
+  label: string
+  description: string
+}
+
+const workflowSteps: WorkflowStep[] = [
+  {
+    id: 1,
+    title: 'Select Customer & PDF',
+    description:
+      'Choose the customer record from QuickBooks and upload the PDF that should be sent through the secure workflow.',
+  },
+  {
+    id: 2,
+    title: 'Lock PDF',
+    description:
+      'Generate an 8-digit access code, lock the PDF, and keep it hidden until the associated payment has been approved.',
+  },
+  {
+    id: 3,
+    title: 'Send Unlock Request',
+    description:
+      'Email the customer a payment link, notify the under processor, and route the document for unlocking once payment clears.',
+    highlight: true,
+  },
+] as const
+
+const stakeholders: Stakeholder[] = [
+  {
+    name: 'Alon',
+    label: 'Initiator',
+    description:
+      'Creates PDFs that need to be distributed securely to customers through the application.',
+  },
+  {
+    name: 'Under Processor',
+    label: 'Automation',
+    description:
+      'Receives unlock requests from the backend and ensures the right agent handles each payment.',
+  },
+  {
+    name: 'Customer',
+    label: 'Recipient',
+    description:
+      'Completes the QuickBooks payment and receives the unlocked document once approved.',
+  },
+] as const
+
+const projectFeatures = [
+  'User interface for selecting a customer and a PDF file that should be sent.',
+  'Functionality of generating a random 8-digit code that will be shown to the customer only after the payment has been approved by QuickBooks.',
+  'Functionality of sending an email to a specific customer with the PDF file and a link to the QuickBooks payment page.',
+] as const
+
+const quickbooksIntegrations = [
+  'Receiving customers via their QuickBooks ID, name, and email address.',
+  'Getting the status of the payment page for a specific customer and payment request.',
+  'Updating the QuickBooks customer record with the auto-generated password.',
+  'Adding the auto-generated password that will be presented to the user after the payment has been processed and approved.',
+] as const
+
+const generalProcess = [
+  'As part of our software development cycle, we start by creating clear software design documents which will be reviewed with the client before the implementation phase will start. During and after the software implementation phase we will provide several versions of early stage product releases to receive customer feedback as early as possible and to make sure the end product will meet the customer\'s expectations.',
+  'Any changes that will be required during the intermediate releases will be assessed and discussed. If they present a change in scope they might need to be implemented instead of other requirements or will require additional payment. No changes that will require additional payments will be implemented without the written consent of the client.',
+] as const
+
+function App() {
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div className="app">
+      <header className="hero">
+        <div className="hero__content">
+          <div className="hero__top">
+            <div className="hero__brand">
+              <div className="hero__logo">VIS2</div>
+              <div>
+                <span className="hero__company">VIS2MIS</span>
+                <p className="hero__tagline">The source of the record</p>
+              </div>
+            </div>
+            <div className="hero__contact">
+              <a href="mailto:info@vis2mis.com">info@vis2mis.com</a>
+              <a href="https://www.vis2mis.com" target="_blank" rel="noreferrer">
+                www.vis2mis.com
+              </a>
+            </div>
+          </div>
+          <div className="hero__body">
+            <span className="hero__pill">Custom customer application</span>
+            <h1 className="hero__title">Alon's Application</h1>
+            <p className="hero__subtitle">
+              A secure workflow that locks PDFs until payment is received and automates updates in QuickBooks.
+            </p>
+            <div className="hero__actions">
+              <a className="hero__cta" href="#project-details">
+                Explore the project scope
+              </a>
+              <span className="hero__note">Design preview · Implementation ready</span>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <main className="content">
+        <section className="section section--description" id="description">
+          <div className="section__header">
+            <h2>Description</h2>
+            <p>
+              The custom application that will be developed will perform the tasks described in the workflow and deliver a
+              polished experience for customers, operators, and processors.
+            </p>
+          </div>
+          <div className="workflow">
+            <div className="workflow__intro">
+              <h3>Customer Application Workflow</h3>
+              <p>
+                Every request begins with Alon generating a PDF. The application then guides the team through a structured
+                locking and payment process before releasing the document to the customer.
+              </p>
+            </div>
+            <div className="workflow__grid">
+              {workflowSteps.map((step) => (
+                <article
+                  key={step.id}
+                  className={`step-card${step.highlight ? ' step-card--highlight' : ''}`}
+                >
+                  <div className="step-card__number">{step.id}</div>
+                  <h4>{step.title}</h4>
+                  <p>{step.description}</p>
+                </article>
+              ))}
+            </div>
+            <p className="workflow__note">Key stakeholders that collaborate within the workflow:</p>
+            <div className="workflow__roles">
+              {stakeholders.map((stakeholder) => (
+                <div key={stakeholder.name} className="stakeholder-card">
+                  <span className="stakeholder-card__label">{stakeholder.label}</span>
+                  <h5>{stakeholder.name}</h5>
+                  <p>{stakeholder.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="section section--project" id="project-details">
+          <div className="section__header">
+            <h2>Project Details</h2>
+            <p>The custom application that will be developed will include the following features:</p>
+          </div>
+          <div className="project-lists">
+            <ul className="feature-list">
+              {projectFeatures.map((feature) => (
+                <li key={feature}>{feature}</li>
+              ))}
+            </ul>
+            <div className="feature-panel">
+              <h3>QuickBooks Integrations</h3>
+              <ul>
+                {quickbooksIntegrations.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        <section className="section section--process">
+          <div className="section__header">
+            <h2>General Process</h2>
+            <p>
+              Our delivery model emphasizes collaboration, transparency, and incremental releases to incorporate feedback and
+              guarantee a compliant final product.
+            </p>
+          </div>
+          <div className="process-timeline">
+            {generalProcess.map((paragraph, index) => (
+              <article key={paragraph} className="process-timeline__item">
+                <div className="process-timeline__badge">{index + 1}</div>
+                <p>{paragraph}</p>
+              </article>
+            ))}
+          </div>
+        </section>
+      </main>
+    </div>
   )
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,39 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #17223b;
+  background-color: #eef2f9;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #f6f8fc 0%, #eef2f9 100%);
+  color: inherit;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: #2563eb;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+a:hover {
+  text-decoration: underline;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
 }


### PR DESCRIPTION
## Summary
- replace the starter Vite counter page with a marketing-style layout for Alon's Application
- add structured sections for the workflow, project details, and general process based on the provided product requirements
- refresh global styling to support the new layout with gradients, cards, and responsive typography

## Testing
- npm run build
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cb6468cc70832f8107b707d62ea5f4