### PR TITLE
test(frontend): add hash router unit tests

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -9,6 +9,7 @@ lerna-debug.log*
 
 node_modules
 dist
+dist-test
 dist-ssr
 *.local
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "npm run test:build && node --test tests",
+    "test:build": "rm -rf dist-test && tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "axios": "^1.12.2",

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,42 +1,308 @@
-#root {
-  max-width: 1280px;
-  margin: 0 auto;
-  padding: 2rem;
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, #e2e8f0 0%, #f8fafc 55%, #ffffff 100%);
+  color: #0f172a;
+}
+
+.skip-link {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform: translate(-120%, -120%);
+  padding: 0.75rem 1.25rem;
+  background: #1d4ed8;
+  color: #f8fafc;
+  border-radius: 999px;
+  font-weight: 600;
+  box-shadow: 0 12px 32px rgba(37, 99, 235, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  z-index: 999;
+}
+
+.skip-link:focus {
+  transform: translate(1rem, 1rem);
+  outline: none;
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1rem clamp(1rem, 4vw, 2.75rem);
+  background: rgba(15, 23, 42, 0.96);
+  color: #f8fafc;
+  backdrop-filter: blur(16px);
+  box-shadow: 0 14px 34px rgba(15, 23, 42, 0.35);
+}
+
+.brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: inherit;
+  text-decoration: none;
+  transition: transform 0.2s ease;
+}
+
+.brand:hover {
+  transform: translateY(-1px);
+}
+
+.brand-icon {
+  font-size: 1.6rem;
+}
+
+.brand-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.app-nav {
+  margin-left: auto;
+}
+
+.nav-list {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nav-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.45rem 1rem;
+  border-radius: 999px;
+  font-weight: 500;
+  color: #e2e8f0;
+  background: transparent;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+}
+
+.nav-link:hover {
+  color: #ffffff;
+  background: rgba(248, 250, 252, 0.18);
+  transform: translateY(-1px);
+}
+
+.nav-link:focus-visible {
+  outline: 2px solid #facc15;
+  outline-offset: 4px;
+}
+
+.nav-link-active {
+  color: #ffffff;
+  background: rgba(248, 250, 252, 0.25);
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.25);
+}
+
+.app-main {
+  flex: 1;
+  display: flex;
+  justify-content: center;
+  padding: clamp(2rem, 5vw, 3.5rem) clamp(1.5rem, 5vw, 3rem);
+}
+
+.app-main > * {
+  width: min(960px, 100%);
+}
+
+.app-footer {
+  padding: 1.5rem clamp(1.5rem, 4vw, 3rem);
   text-align: center;
+  font-size: 0.95rem;
+  color: #475569;
+  background: rgba(255, 255, 255, 0.75);
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.page {
+  display: grid;
+  gap: clamp(2rem, 4vw, 3rem);
+  align-content: start;
+  color: #1f2937;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
+.surface {
+  background-color: rgba(255, 255, 255, 0.92);
+  border-radius: 1.5rem;
+  padding: clamp(1.75rem, 4vw, 2.75rem);
+  box-shadow: 0 24px 48px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  backdrop-filter: blur(12px);
+}
+
+.page-hero {
+  display: grid;
+  gap: 1.25rem;
+  align-content: start;
+  background-image: linear-gradient(
+    135deg,
+    rgba(37, 99, 235, 0.14),
+    rgba(29, 78, 216, 0.05)
+  );
+}
+
+.page-header {
+  display: grid;
+  gap: 1rem;
+  align-content: start;
+}
+
+.page-eyebrow {
+  margin: 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #2563eb;
+}
+
+.page-lead {
+  font-size: clamp(1.05rem, 2.6vw, 1.3rem);
+  line-height: 1.7;
+  color: #334155;
+  margin: 0;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  align-items: center;
+}
+
+.primary-button,
+.secondary-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  padding: 0.65rem 1.4rem;
+  font-weight: 600;
+  font-size: 1rem;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, color 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #2563eb, #1d4ed8);
+  color: #ffffff;
+  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.32);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 38px rgba(29, 78, 216, 0.35);
+}
+
+.primary-button:focus-visible {
+  outline: 3px solid rgba(250, 204, 21, 0.85);
+  outline-offset: 4px;
+}
+
+.secondary-button {
+  background: rgba(37, 99, 235, 0.1);
+  color: #1d4ed8;
+  border: 1px solid rgba(37, 99, 235, 0.3);
+}
+
+.secondary-button:hover {
+  background: rgba(37, 99, 235, 0.18);
+  transform: translateY(-1px);
+}
+
+.feature-grid,
+.info-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  align-items: stretch;
+}
+
+.feature-card h2,
+.info-card h2 {
+  margin-top: 0;
+  margin-bottom: 0.6rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.feature-card p,
+.info-card p {
+  margin: 0;
+  color: #4b5563;
+  line-height: 1.65;
+}
+
+.placeholder-card {
+  border-style: dashed;
+  border-color: rgba(37, 99, 235, 0.35);
+  background-image: linear-gradient(
+    135deg,
+    rgba(191, 219, 254, 0.45),
+    rgba(219, 234, 254, 0.15)
+  );
+}
+
+.bullet-list {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  color: #4b5563;
+}
+
+.bullet-list li {
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    justify-content: center;
+    text-align: center;
   }
-  to {
-    transform: rotate(360deg);
+
+  .app-nav {
+    width: 100%;
+  }
+
+  .nav-list {
+    justify-content: center;
+  }
+
+  .app-main {
+    padding: 2rem 1.25rem 3rem;
   }
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
+@media (max-width: 480px) {
+  .primary-button,
+  .secondary-button {
+    width: 100%;
   }
-}
 
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
+  .feature-grid,
+  .info-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,34 +1,81 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import type { ReactNode } from 'react'
+import { useEffect, useMemo } from 'react'
 import './App.css'
+import { useHashRouter } from './hooks/useHashRouter'
+import AboutPage from './pages/AboutPage'
+import HomePage from './pages/HomePage'
+import NotFoundPage from './pages/NotFoundPage'
+import UnlockPage from './pages/UnlockPage'
+
+type RouteDefinition = {
+  path: string
+  label: string
+  element: ReactNode
+}
+
+const routes: RouteDefinition[] = [
+  { path: '/', label: 'Home', element: <HomePage /> },
+  { path: '/unlock', label: 'Unlock', element: <UnlockPage /> },
+  { path: '/about', label: 'About', element: <AboutPage /> },
+]
 
 function App() {
-  const [count, setCount] = useState(0)
+  const { path, navigate } = useHashRouter()
+
+  const activeRoute = useMemo(
+    () => routes.find((route) => route.path === path),
+    [path],
+  )
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return
+    }
+
+    const pageLabel = activeRoute?.label ?? 'Not found'
+    document.title = `${pageLabel} | PDF Unlock`
+  }, [activeRoute])
+
+  const mainContent = activeRoute?.element ?? (
+    <NotFoundPage onNavigateHome={() => navigate('/')} />
+  )
+  const currentYear = new Date().getFullYear()
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
+    <div className="app-shell">
+      <a className="skip-link" href="#main-content">
+        Skip to main content
+      </a>
+      <header className="app-header">
+        <a className="brand" href="#/" aria-label="PDF Unlock home">
+          <span className="brand-icon" aria-hidden="true">
+            🔓
+          </span>
+          <span className="brand-label">PDF Unlock</span>
         </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+        <nav className="app-nav" aria-label="Primary">
+          <ul className="nav-list">
+            {routes.map((route) => (
+              <li key={route.path}>
+                <a
+                  href={`#${route.path}`}
+                  className={`nav-link${path === route.path ? ' nav-link-active' : ''}`}
+                  aria-current={path === route.path ? 'page' : undefined}
+                >
+                  {route.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </header>
+      <main className="app-main" id="main-content" tabIndex={-1}>
+        {mainContent}
+      </main>
+      <footer className="app-footer">
+        <p>© {currentYear} PDF Unlock. All rights reserved.</p>
+      </footer>
+    </div>
   )
 }
 

--- a/frontend/src/hooks/useHashRouter.ts
+++ b/frontend/src/hooks/useHashRouter.ts
@@ -1,0 +1,70 @@
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
+
+export const normalizePath = (path: string): string => {
+  if (!path) {
+    return '/'
+  }
+
+  const sanitized = path.startsWith('#') ? path.slice(1) : path
+  if (!sanitized.startsWith('/')) {
+    return `/${sanitized}`
+  }
+
+  return sanitized
+}
+
+export const getHashPath = (): string => {
+  if (typeof window === 'undefined') {
+    return '/'
+  }
+
+  return normalizePath(window.location.hash)
+}
+
+export const subscribeToHashChanges = (onChange: () => void): (() => void) => {
+  if (typeof window === 'undefined') {
+    return () => {}
+  }
+
+  const handleHashChange = () => {
+    onChange()
+  }
+
+  window.addEventListener('hashchange', handleHashChange)
+  return () => window.removeEventListener('hashchange', handleHashChange)
+}
+
+export const applyHashNavigation = (nextPath: string): void => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const normalized = normalizePath(nextPath)
+  if (normalizePath(window.location.hash) === normalized) {
+    return
+  }
+
+  window.location.hash = normalized
+}
+
+const getServerPath = () => '/'
+
+export const useHashRouter = () => {
+  const path = useSyncExternalStore(
+    subscribeToHashChanges,
+    getHashPath,
+    getServerPath,
+  )
+
+  const navigate = useCallback((nextPath: string) => {
+    applyHashNavigation(nextPath)
+  }, [])
+
+  return useMemo(
+    () => ({
+      path,
+      navigate,
+    }),
+    [path, navigate],
+  )
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,68 +1,68 @@
 :root {
-  font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, 'Helvetica Neue', Arial,
+    sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
+  color: #0f172a;
+  background-color: #e2e8f0;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  color-scheme: light;
+  scroll-behavior: smooth;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
+  min-height: 100vh;
+  background: linear-gradient(180deg, #e2e8f0 0%, #f8fafc 45%, #eef2ff 100%);
+  color: #0f172a;
+}
+
+#root {
   min-height: 100vh;
 }
 
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible {
+  outline: 2px solid #1d4ed8;
+  outline-offset: 3px;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  margin: 0;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+p {
+  margin: 0;
+  color: #475569;
+}
+
+ul {
+  margin: 0;
+  padding: 0;
 }
 
 button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
   font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+img {
+  max-width: 100%;
+  display: block;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
-import App from './App.tsx'
+import App from './App'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,0 +1,42 @@
+import type { FC } from 'react'
+
+const AboutPage: FC = () => (
+  <section className="page" aria-labelledby="about-title">
+    <div className="page-header surface">
+      <h1 id="about-title">Built for secure document collaboration</h1>
+      <p>
+        The PDF Unlock project focuses on transparent tooling for handling sensitive files.
+        We believe removing restrictions should be simple, auditable, and respectful of the
+        people who own the documents.
+      </p>
+    </div>
+
+    <div className="info-grid" role="list">
+      <article className="info-card surface" role="listitem">
+        <h2>Why unlock PDFs?</h2>
+        <p>
+          Password-protected documents help keep information secure, yet the same controls can
+          slow down collaboration. Providing a safe, user-friendly way to remove those locks
+          keeps teams moving without compromising trust.
+        </p>
+      </article>
+      <article className="info-card surface" role="listitem">
+        <h2>What to expect next</h2>
+        <p>
+          Upcoming iterations will introduce role-based access, audit logs for every unlock
+          operation, and automated clean-up routines so you can meet internal compliance goals.
+        </p>
+      </article>
+      <article className="info-card surface" role="listitem">
+        <h2>How to contribute</h2>
+        <p>
+          We are actively drafting the core unlocking workflow. Share feedback, report issues,
+          or suggest integrations to help shape the roadmap and make the tool fit real-world
+          teams.
+        </p>
+      </article>
+    </div>
+  </section>
+)
+
+export default AboutPage

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,0 +1,49 @@
+import type { FC } from 'react'
+
+const HomePage: FC = () => (
+  <section className="page" aria-labelledby="home-title">
+    <div className="page-hero surface">
+      <p className="page-eyebrow">PDF Unlock</p>
+      <h1 id="home-title">Effortless PDF unlocking for every workflow</h1>
+      <p className="page-lead">
+        Securely remove passwords and usage restrictions from your PDF documents. Upload
+        a file, choose the unlock options that fit your needs, and download the document in
+        seconds.
+      </p>
+      <div className="action-row">
+        <a className="primary-button" href="#/unlock">
+          Start unlocking
+        </a>
+        <a className="secondary-button" href="#/about">
+          Learn about the project
+        </a>
+      </div>
+    </div>
+
+    <div className="feature-grid" role="list">
+      <article className="feature-card surface" role="listitem">
+        <h2>Privacy first</h2>
+        <p>
+          Files stay on your device while we prepare the unlocking workflow. Nothing is
+          stored on external servers.
+        </p>
+      </article>
+      <article className="feature-card surface" role="listitem">
+        <h2>Guided experience</h2>
+        <p>
+          Step-by-step prompts walk you through decrypting a file, making the process
+          approachable even if you are new to PDFs.
+        </p>
+      </article>
+      <article className="feature-card surface" role="listitem">
+        <h2>Productivity ready</h2>
+        <p>
+          Coming soon: integrations with your favourite cloud providers to streamline team
+          workflows and archive unlocked documents automatically.
+        </p>
+      </article>
+    </div>
+  </section>
+)
+
+export default HomePage

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,0 +1,22 @@
+import type { FC } from 'react'
+
+type NotFoundPageProps = {
+  onNavigateHome: () => void
+}
+
+const NotFoundPage: FC<NotFoundPageProps> = ({ onNavigateHome }) => (
+  <section className="page" aria-labelledby="not-found-title">
+    <div className="page-hero surface">
+      <h1 id="not-found-title">We couldn’t find that page</h1>
+      <p>
+        The link you followed might be out of date or the page may have been moved. Return to
+        the dashboard to continue working with your PDF documents.
+      </p>
+      <button type="button" className="primary-button" onClick={onNavigateHome}>
+        Back to home
+      </button>
+    </div>
+  </section>
+)
+
+export default NotFoundPage

--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -1,0 +1,44 @@
+import type { FC } from 'react'
+
+const UnlockPage: FC = () => (
+  <section className="page" aria-labelledby="unlock-title">
+    <div className="page-header surface">
+      <h1 id="unlock-title">Unlock a protected PDF</h1>
+      <p>
+        This guided flow will soon let you upload a password-protected PDF, confirm that you
+        own the document, and export an unrestricted copy for editing and collaboration.
+      </p>
+    </div>
+
+    <div className="placeholder-card surface" role="status" aria-live="polite">
+      <p className="page-lead">
+        The unlocking form is on its way. In the meantime, review the preparation checklist
+        below so you are ready when the uploader arrives.
+      </p>
+    </div>
+
+    <div className="info-grid" role="list">
+      <article className="info-card surface" role="listitem">
+        <h2>Preparation checklist</h2>
+        <ul className="bullet-list">
+          <li>Locate the original password or owner permissions for the document.</li>
+          <li>Confirm that you are authorised to remove restrictions from the PDF.</li>
+          <li>
+            Decide whether you want to keep metadata, annotations, or digital signatures when
+            exporting the unlocked copy.
+          </li>
+        </ul>
+      </article>
+      <article className="info-card surface" role="listitem">
+        <h2>What happens next?</h2>
+        <p>
+          We will guide you through uploading the file, verifying ownership, and choosing the
+          exact restrictions to lift. Expect support for bulk operations and automated
+          retention policies soon.
+        </p>
+      </article>
+    </div>
+  </section>
+)
+
+export default UnlockPage

--- a/frontend/tests/useHashRouter.test.js
+++ b/frontend/tests/useHashRouter.test.js
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict'
+import { afterEach, beforeEach, describe, it } from 'node:test'
+
+import {
+  applyHashNavigation,
+  getHashPath,
+  normalizePath,
+  subscribeToHashChanges,
+} from '../dist-test/hooks/useHashRouter.js'
+
+const createMockWindow = (initialHash = '#/') => {
+  let currentHash = initialHash
+  let writeCount = 0
+  const listeners = new Map()
+
+  return {
+    location: {
+      get hash() {
+        return currentHash
+      },
+      set hash(value) {
+        currentHash = value.startsWith('#') ? value : `#${value}`
+        writeCount += 1
+      },
+    },
+    addEventListener(type, listener) {
+      if (!listeners.has(type)) {
+        listeners.set(type, new Set())
+      }
+      listeners.get(type).add(listener)
+    },
+    removeEventListener(type, listener) {
+      const bucket = listeners.get(type)
+      if (!bucket) {
+        return
+      }
+      bucket.delete(listener)
+    },
+    emit(type) {
+      const bucket = listeners.get(type)
+      if (!bucket) {
+        return
+      }
+      for (const listener of bucket) {
+        listener()
+      }
+    },
+    getHash() {
+      return currentHash
+    },
+    getWriteCount() {
+      return writeCount
+    },
+    resetWriteCount() {
+      writeCount = 0
+    },
+  }
+}
+
+describe('normalizePath', () => {
+  it('defaults to the root path when empty', () => {
+    assert.equal(normalizePath(''), '/')
+  })
+
+  it('ensures the path includes a leading slash', () => {
+    assert.equal(normalizePath('unlock'), '/unlock')
+  })
+
+  it('removes leading hash fragments', () => {
+    assert.equal(normalizePath('#/about'), '/about')
+  })
+})
+
+describe('getHashPath', () => {
+  afterEach(() => {
+    delete globalThis.window
+  })
+
+  it('returns the root path when no window is present', () => {
+    delete globalThis.window
+    assert.equal(getHashPath(), '/')
+  })
+
+  it('normalizes the current hash from the window', () => {
+    const mockWindow = createMockWindow('#/unlock')
+    globalThis.window = mockWindow
+
+    assert.equal(getHashPath(), '/unlock')
+  })
+})
+
+describe('applyHashNavigation', () => {
+  let mockWindow
+
+  beforeEach(() => {
+    mockWindow = createMockWindow('#/current')
+    globalThis.window = mockWindow
+    mockWindow.resetWriteCount()
+  })
+
+  afterEach(() => {
+    delete globalThis.window
+  })
+
+  it('normalizes and updates the hash location', () => {
+    applyHashNavigation('unlock')
+
+    assert.equal(mockWindow.getHash(), '#/unlock')
+    assert.equal(mockWindow.getWriteCount(), 1)
+  })
+
+  it('ignores navigation requests that match the current location', () => {
+    applyHashNavigation('/current')
+
+    assert.equal(mockWindow.getHash(), '#/current')
+    assert.equal(mockWindow.getWriteCount(), 0)
+  })
+
+  it('does nothing when window is unavailable', () => {
+    delete globalThis.window
+
+    applyHashNavigation('/anywhere')
+    // Should not throw
+  })
+})
+
+describe('subscribeToHashChanges', () => {
+  afterEach(() => {
+    delete globalThis.window
+  })
+
+  it('registers and cleans up hash change listeners', () => {
+    const mockWindow = createMockWindow('#/')
+    globalThis.window = mockWindow
+
+    let callCount = 0
+    const unsubscribe = subscribeToHashChanges(() => {
+      callCount += 1
+    })
+
+    mockWindow.emit('hashchange')
+    assert.equal(callCount, 1)
+
+    unsubscribe()
+    mockWindow.emit('hashchange')
+    assert.equal(callCount, 1)
+  })
+
+  it('returns a noop cleanup when no window is present', () => {
+    delete globalThis.window
+
+    const cleanup = subscribeToHashChanges(() => {
+      throw new Error('listener should not run without a window')
+    })
+
+    cleanup()
+  })
+})

--- a/frontend/tsconfig.test.json
+++ b/frontend/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-test",
+    "declaration": false,
+    "emitDeclarationOnly": false,
+    "allowImportingTsExtensions": false
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"]
+}


### PR DESCRIPTION
## Summary
- refactor the hash router hook to expose reusable helpers and rely on useSyncExternalStore
- add a node:test-based unit suite for the hash router along with the TypeScript build config it requires
- wire npm test scripts and ignore the dist-test artifacts generated during compilation

## Testing
- npm run lint
- npm run build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc70b33728832fa4cd88a9c97d5d7a