### PR TITLE
feat: add API state management provider

### DIFF
--- a/frontend/src/api/ApiProvider.tsx
+++ b/frontend/src/api/ApiProvider.tsx
@@ -1,0 +1,65 @@
+import type { FC, ReactNode } from 'react'
+import { useCallback, useMemo, useReducer } from 'react'
+import { createApiClient, type CreateApiClientOptions } from './client'
+import { ApiContext, type ApiContextValue } from './context'
+import { apiStateReducer } from './state'
+
+export type ApiProviderProps = {
+  children: ReactNode
+  baseUrl?: string
+  withCredentials?: CreateApiClientOptions['withCredentials']
+}
+
+export const ApiProvider: FC<ApiProviderProps> = ({
+  children,
+  baseUrl = '/api',
+  withCredentials,
+}) => {
+  const client = useMemo(
+    () => createApiClient({ baseUrl, withCredentials }),
+    [baseUrl, withCredentials],
+  )
+  const [state, dispatch] = useReducer(apiStateReducer, {})
+
+  const startRequest = useCallback(
+    (cacheKey: string) => {
+      dispatch({ type: 'start', key: cacheKey })
+    },
+    [dispatch],
+  )
+
+  const fulfillRequest = useCallback(
+    (cacheKey: string, data: unknown) => {
+      dispatch({ type: 'success', key: cacheKey, data })
+    },
+    [dispatch],
+  )
+
+  const failRequest = useCallback(
+    (cacheKey: string, error: unknown) => {
+      dispatch({ type: 'error', key: cacheKey, error })
+    },
+    [dispatch],
+  )
+
+  const invalidate = useCallback(
+    (cacheKey?: string) => {
+      dispatch({ type: 'invalidate', key: cacheKey })
+    },
+    [dispatch],
+  )
+
+  const value = useMemo<ApiContextValue>(
+    () => ({
+      client,
+      state,
+      startRequest,
+      fulfillRequest,
+      failRequest,
+      invalidate,
+    }),
+    [client, state, startRequest, fulfillRequest, failRequest, invalidate],
+  )
+
+  return <ApiContext.Provider value={value}>{children}</ApiContext.Provider>
+}

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,21 @@
+import axios, { type AxiosInstance } from 'axios'
+
+export type CreateApiClientOptions = {
+  baseUrl?: string
+  withCredentials?: boolean
+}
+
+export const createApiClient = (
+  options: CreateApiClientOptions = {},
+): AxiosInstance => {
+  const { baseUrl = '/api', withCredentials = false } = options
+
+  return axios.create({
+    baseURL: baseUrl,
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    withCredentials,
+  })
+}

--- a/frontend/src/api/context.ts
+++ b/frontend/src/api/context.ts
@@ -1,0 +1,34 @@
+import { createContext, useCallback, useContext } from 'react'
+import type { AxiosInstance } from 'axios'
+import { serializeQueryKey, type ApiState, type QueryKey } from './state'
+
+export type ApiContextValue = {
+  client: AxiosInstance
+  state: ApiState
+  startRequest: (cacheKey: string) => void
+  fulfillRequest: (cacheKey: string, data: unknown) => void
+  failRequest: (cacheKey: string, error: unknown) => void
+  invalidate: (cacheKey?: string) => void
+}
+
+export const ApiContext = createContext<ApiContextValue | null>(null)
+
+export const useApiContext = (): ApiContextValue => {
+  const context = useContext(ApiContext)
+  if (!context) {
+    throw new Error('useApiContext must be used within an ApiProvider')
+  }
+
+  return context
+}
+
+export const useInvalidateQuery = () => {
+  const { invalidate } = useApiContext()
+
+  return useCallback(
+    (key?: QueryKey) => {
+      invalidate(key ? serializeQueryKey(key) : undefined)
+    },
+    [invalidate],
+  )
+}

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,0 +1,18 @@
+export { ApiProvider, type ApiProviderProps } from './ApiProvider'
+export { useApiContext, useInvalidateQuery, type ApiContextValue } from './context'
+export { createApiClient, type CreateApiClientOptions } from './client'
+export {
+  useApiQuery,
+  DEFAULT_STALE_TIME,
+  type UseApiQueryOptions,
+  type UseApiQueryResult,
+} from './useApiQuery'
+export {
+  apiStateReducer,
+  serializeQueryKey,
+  type ApiAction,
+  type ApiEntry,
+  type ApiState,
+  type ApiStatus,
+  type QueryKey,
+} from './state'

--- a/frontend/src/api/state.ts
+++ b/frontend/src/api/state.ts
@@ -1,0 +1,81 @@
+export type ApiStatus = 'idle' | 'loading' | 'success' | 'error'
+
+export type ApiEntry<TData = unknown> = {
+  status: ApiStatus
+  data?: TData
+  error?: unknown
+  updatedAt?: number
+}
+
+export type ApiState = Record<string, ApiEntry>
+
+export type ApiAction =
+  | { type: 'start'; key: string }
+  | { type: 'success'; key: string; data: unknown }
+  | { type: 'error'; key: string; error: unknown }
+  | { type: 'invalidate'; key?: string }
+
+export const apiStateReducer = (state: ApiState, action: ApiAction): ApiState => {
+  switch (action.type) {
+    case 'start': {
+      const previousEntry = state[action.key]
+      return {
+        ...state,
+        [action.key]: {
+          status: 'loading',
+          data: previousEntry?.data,
+          error: undefined,
+          updatedAt: previousEntry?.updatedAt,
+        },
+      }
+    }
+    case 'success': {
+      return {
+        ...state,
+        [action.key]: {
+          status: 'success',
+          data: action.data,
+          error: undefined,
+          updatedAt: Date.now(),
+        },
+      }
+    }
+    case 'error': {
+      return {
+        ...state,
+        [action.key]: {
+          status: 'error',
+          data: undefined,
+          error: action.error,
+          updatedAt: Date.now(),
+        },
+      }
+    }
+    case 'invalidate': {
+      if (!action.key) {
+        return {}
+      }
+
+      const nextState = { ...state }
+      delete nextState[action.key]
+      return nextState
+    }
+    default: {
+      return state
+    }
+  }
+}
+
+export type QueryKey = string | readonly unknown[]
+
+export const serializeQueryKey = (key: QueryKey): string => {
+  if (Array.isArray(key)) {
+    return JSON.stringify(key)
+  }
+
+  if (typeof key === 'string') {
+    return key
+  }
+
+  return JSON.stringify(key)
+}

--- a/frontend/src/api/useApiQuery.ts
+++ b/frontend/src/api/useApiQuery.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useMemo } from 'react'
+import type { AxiosInstance } from 'axios'
+import { useApiContext } from './context'
+import type { ApiStatus, QueryKey } from './state'
+import { serializeQueryKey } from './state'
+
+export const DEFAULT_STALE_TIME = 30_000
+
+export type UseApiQueryOptions<TData> = {
+  key: QueryKey
+  queryFn: (client: AxiosInstance) => Promise<TData>
+  enabled?: boolean
+  staleTime?: number
+}
+
+export type UseApiQueryResult<TData> = {
+  data: TData | undefined
+  error: unknown
+  status: ApiStatus
+  isIdle: boolean
+  isLoading: boolean
+  isSuccess: boolean
+  isError: boolean
+  updatedAt: number | null
+  refetch: () => Promise<TData>
+  invalidate: () => void
+}
+
+export function useApiQuery<TData>({
+  key,
+  queryFn,
+  enabled = true,
+  staleTime = DEFAULT_STALE_TIME,
+}: UseApiQueryOptions<TData>): UseApiQueryResult<TData> {
+  const { client, state, startRequest, fulfillRequest, failRequest, invalidate } =
+    useApiContext()
+  const cacheKey = useMemo(() => serializeQueryKey(key), [key])
+  const entry = state[cacheKey]
+
+  const status: ApiStatus = entry?.status ?? 'idle'
+  const isIdle = status === 'idle'
+  const isLoading = status === 'loading'
+  const isSuccess = status === 'success'
+  const isError = status === 'error'
+
+  const lastUpdated = entry?.updatedAt ?? null
+  const resolvedStaleTime = Number.isFinite(staleTime)
+    ? staleTime
+    : Number.POSITIVE_INFINITY
+  const isDataMissing = !entry
+  const isExpired =
+    !isDataMissing &&
+    resolvedStaleTime !== Number.POSITIVE_INFINITY &&
+    typeof lastUpdated === 'number' &&
+    Date.now() - lastUpdated > resolvedStaleTime
+
+  const shouldFetch = enabled && !isLoading && (isDataMissing || isError || isExpired)
+
+  useEffect(() => {
+    if (!shouldFetch) {
+      return
+    }
+
+    let cancelled = false
+
+    startRequest(cacheKey)
+
+    queryFn(client)
+      .then((result) => {
+        if (!cancelled) {
+          fulfillRequest(cacheKey, result)
+        }
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          failRequest(cacheKey, error)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [
+    shouldFetch,
+    cacheKey,
+    queryFn,
+    client,
+    startRequest,
+    fulfillRequest,
+    failRequest,
+  ])
+
+  const refetch = useCallback(async () => {
+    startRequest(cacheKey)
+    try {
+      const result = await queryFn(client)
+      fulfillRequest(cacheKey, result)
+      return result
+    } catch (error) {
+      failRequest(cacheKey, error)
+      throw error
+    }
+  }, [cacheKey, queryFn, client, startRequest, fulfillRequest, failRequest])
+
+  const invalidateSelf = useCallback(() => {
+    invalidate(cacheKey)
+  }, [invalidate, cacheKey])
+
+  return useMemo(
+    () => ({
+      data: entry?.data as TData | undefined,
+      error: entry?.error,
+      status,
+      isIdle,
+      isLoading,
+      isSuccess,
+      isError,
+      updatedAt: typeof lastUpdated === 'number' ? lastUpdated : null,
+      refetch,
+      invalidate: invalidateSelf,
+    }),
+    [
+      entry?.data,
+      entry?.error,
+      status,
+      isIdle,
+      isLoading,
+      isSuccess,
+      isError,
+      lastUpdated,
+      refetch,
+      invalidateSelf,
+    ],
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,9 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
+import { ApiProvider } from './api'
+
+const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '/api'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ApiProvider baseUrl={apiBaseUrl}>
+      <App />
+    </ApiProvider>
   </StrictMode>,
 )

--- a/frontend/tests/apiState.test.js
+++ b/frontend/tests/apiState.test.js
@@ -1,0 +1,130 @@
+import assert from 'node:assert/strict'
+import { afterEach, describe, it } from 'node:test'
+
+import {
+  apiStateReducer,
+  serializeQueryKey,
+} from '../dist-test/api/state.js'
+import { createApiClient } from '../dist-test/api/client.js'
+
+const ORIGINAL_NOW = Date.now
+
+describe('serializeQueryKey', () => {
+  it('returns string keys unchanged', () => {
+    assert.equal(serializeQueryKey('invoices'), 'invoices')
+  })
+
+  it('stringifies array-based keys for caching', () => {
+    assert.equal(serializeQueryKey(['invoices', '123']), '["invoices","123"]')
+  })
+})
+
+describe('apiStateReducer', () => {
+  afterEach(() => {
+    Date.now = ORIGINAL_NOW
+  })
+
+  it('marks a query as loading and preserves existing data', () => {
+    const existingState = {
+      '["docs","status"]': {
+        status: 'success',
+        data: { message: 'ready' },
+        error: new Error('previous error'),
+        updatedAt: 100,
+      },
+    }
+
+    const nextState = apiStateReducer(existingState, {
+      type: 'start',
+      key: '["docs","status"]',
+    })
+
+    assert.equal(nextState['["docs","status"]'].status, 'loading')
+    assert.deepEqual(nextState['["docs","status"]'].data, { message: 'ready' })
+    assert.equal(nextState['["docs","status"]'].error, undefined)
+    assert.equal(nextState['["docs","status"]'].updatedAt, 100)
+  })
+
+  it('stores new data and a timestamp on success', () => {
+    Date.now = () => 4_200
+
+    const nextState = apiStateReducer({}, {
+      type: 'success',
+      key: 'health',
+      data: { status: 'ok' },
+    })
+
+    assert.equal(nextState.health.status, 'success')
+    assert.deepEqual(nextState.health.data, { status: 'ok' })
+    assert.equal(nextState.health.error, undefined)
+    assert.equal(nextState.health.updatedAt, 4_200)
+  })
+
+  it('records error information on failure', () => {
+    Date.now = () => 7_500
+    const failure = new Error('Request failed')
+
+    const nextState = apiStateReducer({}, {
+      type: 'error',
+      key: 'health',
+      error: failure,
+    })
+
+    assert.equal(nextState.health.status, 'error')
+    assert.equal(nextState.health.data, undefined)
+    assert.equal(nextState.health.error, failure)
+    assert.equal(nextState.health.updatedAt, 7_500)
+  })
+
+  it('removes cached entries when invalidated', () => {
+    const populated = {
+      '["docs","status"]': {
+        status: 'success',
+        data: { message: 'ok' },
+        updatedAt: 10,
+      },
+      health: {
+        status: 'success',
+        data: { status: 'ok' },
+        updatedAt: 20,
+      },
+    }
+
+    const cleared = apiStateReducer(populated, { type: 'invalidate', key: 'health' })
+
+    assert.equal(cleared.health, undefined)
+    assert.deepEqual(cleared['["docs","status"]'], populated['["docs","status"]'])
+  })
+
+  it('supports clearing the entire cache', () => {
+    const populated = {
+      anything: {
+        status: 'success',
+        data: { value: 1 },
+        updatedAt: 5,
+      },
+    }
+
+    const cleared = apiStateReducer(populated, { type: 'invalidate' })
+
+    assert.deepEqual(cleared, {})
+  })
+})
+
+describe('createApiClient', () => {
+  it('uses the default base URL when none is provided', () => {
+    const client = createApiClient()
+
+    assert.equal(client.defaults.baseURL, '/api')
+    assert.equal(client.defaults.headers.Accept, 'application/json')
+    assert.equal(client.defaults.headers['Content-Type'], 'application/json')
+  })
+
+  it('respects custom configuration', () => {
+    const client = createApiClient({ baseUrl: 'https://example.test/v1', withCredentials: true })
+
+    assert.equal(client.defaults.baseURL, 'https://example.test/v1')
+    assert.equal(client.defaults.withCredentials, true)
+    assert.equal(client.defaults.headers['Content-Type'], 'application/json')
+  })
+})


### PR DESCRIPTION
## Summary
- implement a custom API provider, context, reducer, and query hook to manage global API state when the registry blocks installing @tanstack/react-query
- add an axios-based API client factory plus barrel exports and wrap the root app with the provider for consistent configuration
- cover the new state layer with unit tests for key serialization, reducer behaviour, and client defaults

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cc794156d4832fbbbe3e10a4b0fe91