### PR TITLE
Add QuickBooks customer dropdown component

### DIFF
--- a/frontend/src/api/ApiProvider.tsx
+++ b/frontend/src/api/ApiProvider.tsx
@@ -1,8 +1,8 @@
 import type { FC, ReactNode } from 'react'
 import { useCallback, useMemo, useReducer } from 'react'
-import { createApiClient, type CreateApiClientOptions } from './client'
-import { ApiContext, type ApiContextValue } from './context'
-import { apiStateReducer } from './state'
+import { createApiClient, type CreateApiClientOptions } from './client.js'
+import { ApiContext, type ApiContextValue } from './context.js'
+import { apiStateReducer } from './state.js'
 
 export type ApiProviderProps = {
   children: ReactNode

--- a/frontend/src/api/context.ts
+++ b/frontend/src/api/context.ts
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext } from 'react'
 import type { AxiosInstance } from 'axios'
-import { serializeQueryKey, type ApiState, type QueryKey } from './state'
+import { serializeQueryKey, type ApiState, type QueryKey } from './state.js'
 
 export type ApiContextValue = {
   client: AxiosInstance

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,12 +1,12 @@
-export { ApiProvider, type ApiProviderProps } from './ApiProvider'
-export { useApiContext, useInvalidateQuery, type ApiContextValue } from './context'
-export { createApiClient, type CreateApiClientOptions } from './client'
+export { ApiProvider, type ApiProviderProps } from './ApiProvider.js'
+export { useApiContext, useInvalidateQuery, type ApiContextValue } from './context.js'
+export { createApiClient, type CreateApiClientOptions } from './client.js'
 export {
   useApiQuery,
   DEFAULT_STALE_TIME,
   type UseApiQueryOptions,
   type UseApiQueryResult,
-} from './useApiQuery'
+} from './useApiQuery.js'
 export {
   apiStateReducer,
   serializeQueryKey,
@@ -15,4 +15,15 @@ export {
   type ApiState,
   type ApiStatus,
   type QueryKey,
-} from './state'
+} from './state.js'
+export {
+  useQuickBooksCustomersQuery,
+  normalizeQuickBooksCustomersResponse,
+  QUICKBOOKS_CUSTOMERS_QUERY_KEY,
+  QUICKBOOKS_CUSTOMERS_STALE_TIME,
+  type QuickBooksCustomer,
+  type QuickBooksCustomersResponse,
+  type QuickBooksCustomersEnvelope,
+  type RawQuickBooksCustomer,
+  type UseQuickBooksCustomersQueryOptions,
+} from './qb.js'

--- a/frontend/src/api/qb.ts
+++ b/frontend/src/api/qb.ts
@@ -1,0 +1,129 @@
+import { useApiQuery } from './useApiQuery.js'
+import type { UseApiQueryResult } from './useApiQuery.js'
+
+export type QuickBooksCustomer = {
+  id: string
+  qbId: string
+  name: string
+  email: string
+}
+
+export type RawQuickBooksCustomer = Partial<QuickBooksCustomer> & Record<string, unknown>
+
+export type QuickBooksCustomersEnvelope = {
+  customers?: RawQuickBooksCustomer[] | null
+}
+
+export type QuickBooksCustomersResponse =
+  | RawQuickBooksCustomer[]
+  | QuickBooksCustomersEnvelope
+  | null
+  | undefined
+
+const QUICKBOOKS_CUSTOMERS_COLLATOR = new Intl.Collator(undefined, {
+  sensitivity: 'base',
+  numeric: true,
+})
+
+export const QUICKBOOKS_CUSTOMERS_QUERY_KEY = ['qb', 'customers'] as const
+
+export const QUICKBOOKS_CUSTOMERS_STALE_TIME = 5 * 60_000
+
+const extractRawCustomers = (
+  payload: QuickBooksCustomersResponse,
+): RawQuickBooksCustomer[] => {
+  if (!payload) {
+    return []
+  }
+
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (Array.isArray(payload.customers)) {
+    return payload.customers
+  }
+
+  return []
+}
+
+const normalizeQuickBooksCustomer = (
+  candidate: unknown,
+): QuickBooksCustomer | null => {
+  if (!candidate || typeof candidate !== 'object') {
+    return null
+  }
+
+  const raw = candidate as RawQuickBooksCustomer
+  const name = typeof raw.name === 'string' ? raw.name.trim() : ''
+  const email = typeof raw.email === 'string' ? raw.email.trim() : ''
+
+  const qbId = (() => {
+    if (typeof raw.qbId === 'string' && raw.qbId.trim()) {
+      return raw.qbId.trim()
+    }
+
+    if (typeof raw.id === 'string' && raw.id.trim()) {
+      return raw.id.trim()
+    }
+
+    return null
+  })()
+
+  if (!name || !email || !qbId) {
+    return null
+  }
+
+  const id = typeof raw.id === 'string' && raw.id.trim() ? raw.id.trim() : qbId
+
+  return {
+    id,
+    qbId,
+    name,
+    email,
+  }
+}
+
+export const normalizeQuickBooksCustomersResponse = (
+  payload: QuickBooksCustomersResponse,
+): QuickBooksCustomer[] => {
+  const rawCustomers = extractRawCustomers(payload)
+  const seen = new Set<string>()
+  const normalized: QuickBooksCustomer[] = []
+
+  for (const entry of rawCustomers) {
+    const customer = normalizeQuickBooksCustomer(entry)
+    if (!customer) {
+      continue
+    }
+
+    if (seen.has(customer.qbId)) {
+      continue
+    }
+
+    seen.add(customer.qbId)
+    normalized.push(customer)
+  }
+
+  return normalized.sort((a, b) => QUICKBOOKS_CUSTOMERS_COLLATOR.compare(a.name, b.name))
+}
+
+export type UseQuickBooksCustomersQueryOptions = {
+  enabled?: boolean
+}
+
+export const useQuickBooksCustomersQuery = (
+  options: UseQuickBooksCustomersQueryOptions = {},
+): UseApiQueryResult<QuickBooksCustomer[]> => {
+  const { enabled = true } = options
+
+  return useApiQuery<QuickBooksCustomer[]>({
+    key: QUICKBOOKS_CUSTOMERS_QUERY_KEY,
+    queryFn: async (client) => {
+      const response = await client.get<QuickBooksCustomersResponse>('/qb/customers')
+      return normalizeQuickBooksCustomersResponse(response.data)
+    },
+    staleTime: QUICKBOOKS_CUSTOMERS_STALE_TIME,
+    enabled,
+  })
+}

--- a/frontend/src/api/useApiQuery.ts
+++ b/frontend/src/api/useApiQuery.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo } from 'react'
 import type { AxiosInstance } from 'axios'
-import { useApiContext } from './context'
-import type { ApiStatus, QueryKey } from './state'
-import { serializeQueryKey } from './state'
+import { useApiContext } from './context.js'
+import type { ApiStatus, QueryKey } from './state.js'
+import { serializeQueryKey } from './state.js'
 
 export const DEFAULT_STALE_TIME = 30_000
 

--- a/frontend/src/components/CustomerDropdown.tsx
+++ b/frontend/src/components/CustomerDropdown.tsx
@@ -1,0 +1,490 @@
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type KeyboardEvent,
+} from 'react'
+import type { QuickBooksCustomer } from '../api/qb'
+import { useQuickBooksCustomersQuery } from '../api/qb'
+
+const combineClassNames = (
+  ...classes: Array<string | false | null | undefined>
+): string => classes.filter(Boolean).join(' ')
+
+const mergeIds = (...ids: Array<string | undefined>): string | undefined => {
+  const filtered = ids.filter(Boolean) as string[]
+  return filtered.length > 0 ? filtered.join(' ') : undefined
+}
+
+const MAX_VISIBLE_RESULTS = 50
+
+export type CustomerDropdownProps = {
+  label?: string
+  placeholder?: string
+  helperText?: string
+  error?: string
+  disabled?: boolean
+  required?: boolean
+  name?: string
+  className?: string
+  onSelect?: (customer: QuickBooksCustomer | null) => void
+}
+
+const CustomerDropdown = ({
+  label = 'Customer',
+  placeholder = 'Search customers…',
+  helperText,
+  error,
+  disabled = false,
+  required = false,
+  name,
+  className,
+  onSelect,
+}: CustomerDropdownProps) => {
+  const {
+    data: customers = [],
+    isLoading,
+    isError,
+    error: requestError,
+    refetch,
+  } = useQuickBooksCustomersQuery({ enabled: !disabled })
+  const [isOpen, setIsOpen] = useState(false)
+  const [inputValue, setInputValue] = useState('')
+  const [userEdited, setUserEdited] = useState(false)
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1)
+  const [selectedCustomer, setSelectedCustomer] = useState<QuickBooksCustomer | null>(null)
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const baseId = useId()
+  const inputId = `${baseId}-input`
+  const listboxId = `${baseId}-listbox`
+  const helperId = helperText ? `${baseId}-helper` : undefined
+  const errorId = error ? `${baseId}-error` : undefined
+
+  const requestErrorMessage = isError
+    ? requestError instanceof Error && requestError.message
+      ? requestError.message
+      : 'Unable to load customers.'
+    : null
+  const requestErrorId = requestErrorMessage ? `${baseId}-request-error` : undefined
+  const describedBy = mergeIds(helperId, requestErrorId, errorId)
+
+  const formatCustomer = useCallback(
+    (customer: QuickBooksCustomer) => `${customer.name} (${customer.email})`,
+    [],
+  )
+
+  const searchTerm = userEdited ? inputValue.trim().toLowerCase() : ''
+
+  const { filteredCustomers, totalMatches, isTruncated } = useMemo(() => {
+    if (!customers.length) {
+      return { filteredCustomers: [] as QuickBooksCustomer[], totalMatches: 0, isTruncated: false }
+    }
+
+    const matches = (searchTerm
+      ? customers.filter((customer) => {
+          const haystack = `${customer.name} ${customer.email} ${customer.qbId}`.toLowerCase()
+          return haystack.includes(searchTerm)
+        })
+      : customers) as QuickBooksCustomer[]
+
+    const limited = matches.slice(0, MAX_VISIBLE_RESULTS)
+
+    return {
+      filteredCustomers: limited,
+      totalMatches: matches.length,
+      isTruncated: matches.length > limited.length,
+    }
+  }, [customers, searchTerm])
+
+  const clearBlurTimeout = useCallback(() => {
+    if (blurTimeoutRef.current) {
+      clearTimeout(blurTimeoutRef.current)
+      blurTimeoutRef.current = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const handlePointerDown = (event: MouseEvent | TouchEvent) => {
+      if (!containerRef.current) {
+        return
+      }
+
+      if (!containerRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('mousedown', handlePointerDown)
+    document.addEventListener('touchstart', handlePointerDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handlePointerDown)
+      document.removeEventListener('touchstart', handlePointerDown)
+    }
+  }, [])
+
+  useEffect(() => () => clearBlurTimeout(), [clearBlurTimeout])
+
+  useEffect(() => {
+    if (disabled) {
+      setIsOpen(false)
+    }
+  }, [disabled])
+
+  useEffect(() => {
+    if (!selectedCustomer) {
+      return
+    }
+
+    const match = customers.find((customer) => customer.qbId === selectedCustomer.qbId)
+
+    if (!match) {
+      setSelectedCustomer(null)
+      if (!userEdited) {
+        setInputValue('')
+      }
+      onSelect?.(null)
+      return
+    }
+
+    if (match !== selectedCustomer) {
+      setSelectedCustomer(match)
+      if (!userEdited) {
+        setInputValue(formatCustomer(match))
+      }
+    }
+  }, [customers, formatCustomer, onSelect, selectedCustomer, userEdited])
+
+  useEffect(() => {
+    if (!isOpen) {
+      setHighlightedIndex(-1)
+      return
+    }
+
+    if (isLoading || requestErrorMessage || filteredCustomers.length === 0) {
+      setHighlightedIndex(-1)
+      return
+    }
+
+    if (selectedCustomer) {
+      const selectedIndex = filteredCustomers.findIndex(
+        (customer) => customer.qbId === selectedCustomer.qbId,
+      )
+
+      if (selectedIndex >= 0) {
+        setHighlightedIndex(selectedIndex)
+        return
+      }
+    }
+
+    setHighlightedIndex(0)
+  }, [
+    filteredCustomers,
+    isLoading,
+    isOpen,
+    requestErrorMessage,
+    selectedCustomer,
+  ])
+
+  const handleSelect = useCallback(
+    (customer: QuickBooksCustomer) => {
+      setSelectedCustomer(customer)
+      setInputValue(formatCustomer(customer))
+      setUserEdited(false)
+      setIsOpen(false)
+      setHighlightedIndex(-1)
+      onSelect?.(customer)
+    },
+    [formatCustomer, onSelect],
+  )
+
+  const handleInputFocus = useCallback(() => {
+    clearBlurTimeout()
+    if (!disabled) {
+      setIsOpen(true)
+    }
+  }, [clearBlurTimeout, disabled])
+
+  const handleInputBlur = useCallback(() => {
+    clearBlurTimeout()
+    blurTimeoutRef.current = setTimeout(() => {
+      setIsOpen(false)
+    }, 120)
+  }, [clearBlurTimeout])
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const nextValue = event.target.value
+      setInputValue(nextValue)
+      setUserEdited(true)
+      setIsOpen(true)
+      setHighlightedIndex(0)
+
+      if (selectedCustomer) {
+        setSelectedCustomer(null)
+        onSelect?.(null)
+      }
+    },
+    [onSelect, selectedCustomer],
+  )
+
+  const handleInputKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (event.key === 'ArrowDown') {
+        event.preventDefault()
+        if (!isOpen) {
+          setIsOpen(true)
+          return
+        }
+
+        if (filteredCustomers.length === 0) {
+          return
+        }
+
+        setHighlightedIndex((prev) => {
+          const nextIndex = prev < filteredCustomers.length - 1 ? prev + 1 : 0
+          return nextIndex
+        })
+        return
+      }
+
+      if (event.key === 'ArrowUp') {
+        event.preventDefault()
+        if (!isOpen) {
+          setIsOpen(true)
+          return
+        }
+
+        if (filteredCustomers.length === 0) {
+          return
+        }
+
+        setHighlightedIndex((prev) => {
+          if (prev <= 0) {
+            return filteredCustomers.length - 1
+          }
+          return prev - 1
+        })
+        return
+      }
+
+      if (event.key === 'Enter') {
+        if (isOpen && highlightedIndex >= 0 && highlightedIndex < filteredCustomers.length) {
+          event.preventDefault()
+          handleSelect(filteredCustomers[highlightedIndex])
+        }
+        return
+      }
+
+      if (event.key === 'Escape') {
+        if (isOpen) {
+          event.preventDefault()
+          setIsOpen(false)
+          setHighlightedIndex(-1)
+        }
+      }
+    },
+    [filteredCustomers, handleSelect, highlightedIndex, isOpen],
+  )
+
+  const statusMessage = (() => {
+    if (isLoading) {
+      return 'Loading customers…'
+    }
+
+    if (requestErrorMessage) {
+      return requestErrorMessage
+    }
+
+    if (!customers.length) {
+      return 'No customers available yet.'
+    }
+
+    if (!filteredCustomers.length && searchTerm) {
+      return `No matches for “${inputValue.trim()}”.`
+    }
+
+    if (!filteredCustomers.length) {
+      return 'No customers found.'
+    }
+
+    return null
+  })()
+
+  const handleRetry = useCallback(() => {
+    clearBlurTimeout()
+    void refetch()
+  }, [clearBlurTimeout, refetch])
+
+  const getOptionId = useCallback(
+    (index: number) => `${baseId}-option-${index}`,
+    [baseId],
+  )
+
+  const comboboxAriaActivedescendant =
+    isOpen && highlightedIndex >= 0 && highlightedIndex < filteredCustomers.length
+      ? getOptionId(highlightedIndex)
+      : undefined
+
+  return (
+    <div
+      className={combineClassNames('relative flex flex-col gap-2', className)}
+      ref={containerRef}
+    >
+      <label className="text-sm font-medium text-slate-700" htmlFor={inputId}>
+        {label}
+        {required ? <span aria-hidden="true" className="ml-1 text-red-600">*</span> : null}
+      </label>
+
+      <div className="relative">
+        <input
+          id={inputId}
+          type="search"
+          role="combobox"
+          autoComplete="off"
+          spellCheck={false}
+          disabled={disabled}
+          aria-disabled={disabled || undefined}
+          aria-controls={listboxId}
+          aria-expanded={isOpen}
+          aria-haspopup="listbox"
+          aria-activedescendant={comboboxAriaActivedescendant}
+          aria-invalid={Boolean(error || requestErrorMessage)}
+          aria-required={required || undefined}
+          aria-describedby={describedBy}
+          value={inputValue}
+          placeholder={placeholder}
+          className={combineClassNames(
+            'w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:bg-slate-100',
+            error || requestErrorMessage ? 'border-red-500 focus:border-red-500 focus:ring-red-200' : null,
+          )}
+          onFocus={handleInputFocus}
+          onBlur={handleInputBlur}
+          onChange={handleInputChange}
+          onKeyDown={handleInputKeyDown}
+        />
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-400"
+        >
+          ▾
+        </span>
+      </div>
+
+      {name ? (
+        <input
+          type="hidden"
+          name={name}
+          value={selectedCustomer ? selectedCustomer.qbId || selectedCustomer.id : ''}
+        />
+      ) : null}
+
+      {helperText ? (
+        <p className="text-xs text-slate-500" id={helperId}>
+          {helperText}
+        </p>
+      ) : null}
+
+      {requestErrorMessage ? (
+        <div
+          className="flex items-center gap-2 text-sm text-amber-700"
+          id={requestErrorId}
+        >
+          <span>{requestErrorMessage}</span>
+          <button
+            type="button"
+            className="rounded-md border border-amber-600/30 bg-amber-100/40 px-2 py-1 text-xs font-semibold text-amber-800 transition hover:bg-amber-100"
+            onClick={handleRetry}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="text-xs text-red-600" id={errorId}>
+          {error}
+        </p>
+      ) : null}
+
+      {isOpen ? (
+        <div className="absolute left-0 right-0 top-full z-20 mt-1">
+          <div className="overflow-hidden rounded-lg border border-slate-200 bg-white shadow-lg shadow-slate-900/10">
+            <ul
+              id={listboxId}
+              role="listbox"
+              aria-label={`${label} options`}
+              className="max-h-64 overflow-y-auto focus:outline-none"
+            >
+              {!isLoading && !requestErrorMessage
+                ? filteredCustomers.map((customer, index) => {
+                    const isSelected =
+                      selectedCustomer?.qbId === customer.qbId ||
+                      selectedCustomer?.id === customer.id
+
+                    const optionClassName = combineClassNames(
+                      'cursor-pointer select-none px-3 py-2 text-sm transition-colors focus:outline-none',
+                      highlightedIndex === index
+                        ? 'bg-blue-600 text-white'
+                        : isSelected
+                          ? 'bg-blue-50 text-blue-700'
+                          : 'hover:bg-blue-50',
+                    )
+
+                    return (
+                      <li
+                        key={customer.qbId ?? customer.id}
+                        id={getOptionId(index)}
+                        role="option"
+                        aria-selected={isSelected}
+                        tabIndex={-1}
+                        className={optionClassName}
+                        title={`${customer.name} • ${customer.email}`}
+                        onPointerDown={(event) => {
+                          event.preventDefault()
+                          clearBlurTimeout()
+                          handleSelect(customer)
+                        }}
+                        onMouseEnter={() => setHighlightedIndex(index)}
+                      >
+                        <div className="font-medium leading-snug">{customer.name}</div>
+                        <div
+                          className={combineClassNames(
+                            'text-xs leading-snug',
+                            highlightedIndex === index
+                              ? 'text-blue-100'
+                              : 'text-slate-500',
+                          )}
+                        >
+                          {customer.email}
+                        </div>
+                      </li>
+                    )
+                  })
+                : null}
+            </ul>
+
+            {statusMessage ? (
+              <div className="border-t border-slate-100 bg-slate-50 px-3 py-2 text-xs text-slate-600" role="status">
+                {statusMessage}
+              </div>
+            ) : null}
+
+            {isTruncated ? (
+              <div className="border-t border-slate-100 bg-slate-50 px-3 py-2 text-xs text-slate-500">
+                Showing the first {filteredCustomers.length} of {totalMatches} customers. Continue typing to narrow your results.
+              </div>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+export default CustomerDropdown

--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -1,50 +1,76 @@
-import type { FC } from 'react'
+import { useState, type FC } from 'react'
 import PageSection from '../components/ui/PageSection'
 import Surface from '../components/ui/Surface'
+import CustomerDropdown from '../components/CustomerDropdown'
+import type { QuickBooksCustomer } from '../api'
 
-const UnlockPage: FC = () => (
-  <PageSection aria-labelledby="unlock-title">
-    <Surface className="grid gap-4">
-      <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="unlock-title">
-        Unlock a protected PDF
-      </h1>
-      <p className="text-base leading-relaxed text-slate-600">
-        This guided flow will soon let you upload a password-protected PDF, confirm that you own the document, and export an
-        unrestricted copy for editing and collaboration.
-      </p>
-    </Surface>
+const UnlockPage: FC = () => {
+  const [selectedCustomer, setSelectedCustomer] = useState<QuickBooksCustomer | null>(null)
 
-    <Surface
-      aria-live="polite"
-      role="status"
-      className="grid gap-4 border-dashed border-blue-500/40 bg-gradient-to-br from-blue-500/15 via-blue-400/5 to-blue-300/5"
-    >
-      <p className="text-lg leading-relaxed text-slate-600">
-        The unlocking form is on its way. In the meantime, review the preparation checklist below so you are ready when the
-        uploader arrives.
-      </p>
-    </Surface>
-
-    <div className="grid gap-6 md:grid-cols-2" role="list">
-      <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">Preparation checklist</h2>
-        <ul className="list-disc space-y-2 pl-5 text-base leading-relaxed text-slate-600">
-          <li>Locate the original password or owner permissions for the document.</li>
-          <li>Confirm that you are authorised to remove restrictions from the PDF.</li>
-          <li>
-            Decide whether you want to keep metadata, annotations, or digital signatures when exporting the unlocked copy.
-          </li>
-        </ul>
-      </Surface>
-      <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">What happens next?</h2>
+  return (
+    <PageSection aria-labelledby="unlock-title">
+      <Surface className="grid gap-4">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="unlock-title">
+          Unlock a protected PDF
+        </h1>
         <p className="text-base leading-relaxed text-slate-600">
-          We will guide you through uploading the file, verifying ownership, and choosing the exact restrictions to lift. Expect
-          support for bulk operations and automated retention policies soon.
+          This guided flow will soon let you upload a password-protected PDF, confirm that you own the document, and export an
+          unrestricted copy for editing and collaboration.
         </p>
       </Surface>
-    </div>
-  </PageSection>
-)
+
+      <Surface
+        aria-live="polite"
+        role="status"
+        className="grid gap-4 border-dashed border-blue-500/40 bg-gradient-to-br from-blue-500/15 via-blue-400/5 to-blue-300/5"
+      >
+        <p className="text-lg leading-relaxed text-slate-600">
+          The unlocking form is on its way. In the meantime, review the preparation checklist below so you are ready when the
+          uploader arrives.
+        </p>
+      </Surface>
+
+      <Surface className="grid gap-4">
+        <h2 className="text-xl font-semibold text-slate-900">QuickBooks customer lookup</h2>
+        <p className="text-base leading-relaxed text-slate-600">
+          Search your connected QuickBooks customers to prefill invoices or associate uploads with the right account. Start
+          typing a name or email address to filter the list.
+        </p>
+        <CustomerDropdown
+          label="Select a customer"
+          placeholder="Start typing a customer name or email…"
+          helperText="Customers sync from QuickBooks automatically. Narrow the search to find the right match quickly."
+          name="qbCustomerId"
+          onSelect={setSelectedCustomer}
+        />
+        <p className="text-sm text-slate-600" aria-live="polite">
+          {selectedCustomer
+            ? `Selected ${selectedCustomer.name} (${selectedCustomer.email}).`
+            : 'No customer selected yet.'}
+        </p>
+      </Surface>
+
+      <div className="grid gap-6 md:grid-cols-2" role="list">
+        <Surface as="article" role="listitem" className="grid gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">Preparation checklist</h2>
+          <ul className="list-disc space-y-2 pl-5 text-base leading-relaxed text-slate-600">
+            <li>Locate the original password or owner permissions for the document.</li>
+            <li>Confirm that you are authorised to remove restrictions from the PDF.</li>
+            <li>
+              Decide whether you want to keep metadata, annotations, or digital signatures when exporting the unlocked copy.
+            </li>
+          </ul>
+        </Surface>
+        <Surface as="article" role="listitem" className="grid gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">What happens next?</h2>
+          <p className="text-base leading-relaxed text-slate-600">
+            We will guide you through uploading the file, verifying ownership, and choosing the exact restrictions to lift. Expect
+            support for bulk operations and automated retention policies soon.
+          </p>
+        </Surface>
+      </div>
+    </PageSection>
+  )
+}
 
 export default UnlockPage

--- a/frontend/tests/quickBooksCustomers.test.js
+++ b/frontend/tests/quickBooksCustomers.test.js
@@ -1,0 +1,55 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { normalizeQuickBooksCustomersResponse } from '../dist-test/api/qb.js'
+
+describe('normalizeQuickBooksCustomersResponse', () => {
+  it('normalizes array responses and sorts by customer name', () => {
+    const result = normalizeQuickBooksCustomersResponse([
+      { qbId: 'qb-2', name: 'Beta Industries', email: 'beta@example.com' },
+      { qbId: 'qb-1', name: 'alpha systems', email: 'alpha@example.com' },
+    ])
+
+    assert.equal(result.length, 2)
+    assert.deepEqual(
+      result.map((customer) => customer.qbId),
+      ['qb-1', 'qb-2'],
+    )
+    assert.equal(result[0].name, 'alpha systems')
+  })
+
+  it('extracts customers from envelope payloads', () => {
+    const result = normalizeQuickBooksCustomersResponse({
+      customers: [
+        { qbId: 'qb-3', name: 'Gamma Labs', email: 'gamma@example.com' },
+        { qbId: 'qb-4', name: 'Delta Works', email: 'delta@example.com' },
+      ],
+    })
+
+    assert.equal(result.length, 2)
+    assert.deepEqual(
+      result.map((customer) => customer.name),
+      ['Delta Works', 'Gamma Labs'],
+    )
+  })
+
+  it('deduplicates by QuickBooks ID, trims fields, and ignores invalid entries', () => {
+    const result = normalizeQuickBooksCustomersResponse([
+      { qbId: 'qb-1', name: ' Alpha Co ', email: 'alpha@example.com ' },
+      { qbId: 'qb-1', name: 'Alpha Duplicate', email: 'duplicate@example.com' },
+      { id: 'legacy-9', name: 'Beta Group', email: 'beta@example.com' },
+      { qbId: '', name: 'No Id', email: 'noid@example.com' },
+      { qbId: 'qb-3', name: '  ', email: 'missing@example.com' },
+      { qbId: 'qb-4', name: 'Delta Holdings', email: '' },
+    ])
+
+    assert.equal(result.length, 2)
+    assert.deepEqual(
+      result,
+      [
+        { id: 'qb-1', qbId: 'qb-1', name: 'Alpha Co', email: 'alpha@example.com' },
+        { id: 'legacy-9', qbId: 'legacy-9', name: 'Beta Group', email: 'beta@example.com' },
+      ],
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add QuickBooks customers API helper with response normalization and caching metadata
- build a searchable CustomerDropdown component that queries /api/qb/customers and exposes selection updates
- surface the dropdown on the Unlock page and add normalization tests for the QuickBooks customer response

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd532a1f78832fb8222d271a8a2d63