### PR TITLE
Ensure customer selection is required

### DIFF
--- a/frontend/src/components/CustomerDropdown.tsx
+++ b/frontend/src/components/CustomerDropdown.tsx
@@ -58,6 +58,7 @@ const CustomerDropdown = ({
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1)
   const [selectedCustomer, setSelectedCustomer] = useState<QuickBooksCustomer | null>(null)
   const containerRef = useRef<HTMLDivElement | null>(null)
+  const inputRef = useRef<HTMLInputElement | null>(null)
   const blurTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const baseId = useId()
   const inputId = `${baseId}-input`
@@ -191,6 +192,31 @@ const CustomerDropdown = ({
     selectedCustomer,
   ])
 
+  const updateCustomValidity = useCallback(
+    (customer: QuickBooksCustomer | null) => {
+      if (!inputRef.current) {
+        return
+      }
+
+      if (disabled || !required) {
+        inputRef.current.setCustomValidity('')
+        return
+      }
+
+      if (customer) {
+        inputRef.current.setCustomValidity('')
+        return
+      }
+
+      inputRef.current.setCustomValidity('Please select a customer from the list.')
+    },
+    [disabled, required],
+  )
+
+  useEffect(() => {
+    updateCustomValidity(selectedCustomer)
+  }, [selectedCustomer, updateCustomValidity])
+
   const handleSelect = useCallback(
     (customer: QuickBooksCustomer) => {
       setSelectedCustomer(customer)
@@ -198,9 +224,10 @@ const CustomerDropdown = ({
       setUserEdited(false)
       setIsOpen(false)
       setHighlightedIndex(-1)
+      updateCustomValidity(customer)
       onSelect?.(customer)
     },
-    [formatCustomer, onSelect],
+    [formatCustomer, onSelect, updateCustomValidity],
   )
 
   const handleInputFocus = useCallback(() => {
@@ -229,8 +256,10 @@ const CustomerDropdown = ({
         setSelectedCustomer(null)
         onSelect?.(null)
       }
+
+      updateCustomValidity(null)
     },
-    [onSelect, selectedCustomer],
+    [onSelect, selectedCustomer, updateCustomValidity],
   )
 
   const handleInputKeyDown = useCallback(
@@ -359,10 +388,12 @@ const CustomerDropdown = ({
           aria-describedby={describedBy}
           value={inputValue}
           placeholder={placeholder}
+          required={required}
           className={combineClassNames(
             'w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm transition focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:bg-slate-100',
             error || requestErrorMessage ? 'border-red-500 focus:border-red-500 focus:ring-red-200' : null,
           )}
+          ref={inputRef}
           onFocus={handleInputFocus}
           onBlur={handleInputBlur}
           onChange={handleInputChange}

--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -40,6 +40,7 @@ const UnlockPage: FC = () => {
           label="Select a customer"
           placeholder="Start typing a customer name or email…"
           helperText="Customers sync from QuickBooks automatically. Narrow the search to find the right match quickly."
+          required
           name="qbCustomerId"
           onSelect={setSelectedCustomer}
         />


### PR DESCRIPTION
## Summary
- ensure the customer combobox enforces selection when marked as required by wiring up the HTML validity state
- propagate the required flag in the unlock flow so users must choose a customer before proceeding

## Testing
- npm test --prefix frontend
- npm test --prefix backend

------
https://chatgpt.com/codex/tasks/task_e_68cd57af65b0832fbaca7619b9073992