### PR TITLE
Add PDF upload dropzone with validation

### DIFF
--- a/frontend/src/components/PdfUploader.tsx
+++ b/frontend/src/components/PdfUploader.tsx
@@ -1,0 +1,190 @@
+import {
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type DragEvent,
+  type KeyboardEvent,
+} from 'react'
+
+export type PdfUploaderProps = {
+  onFileChange?: (file: File | null) => void
+  ariaLabelledBy?: string
+}
+
+const isPdfFile = (file: File) =>
+  file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf')
+
+const formatFileSize = (sizeInBytes: number) => {
+  if (sizeInBytes >= 1024 * 1024) {
+    return `${(sizeInBytes / (1024 * 1024)).toFixed(2)} MB`
+  }
+
+  if (sizeInBytes >= 1024) {
+    return `${(sizeInBytes / 1024).toFixed(1)} KB`
+  }
+
+  return `${sizeInBytes} bytes`
+}
+
+const PdfUploader = ({ onFileChange, ariaLabelledBy }: PdfUploaderProps) => {
+  const inputId = useId()
+  const descriptionId = `${inputId}-description`
+  const statusId = `${inputId}-status`
+  const errorId = `${inputId}-error`
+
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+  const [isDragging, setIsDragging] = useState(false)
+  const [selectedFile, setSelectedFile] = useState<File | null>(null)
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const handleFiles = useCallback(
+    (files: FileList | null) => {
+      if (!files || files.length === 0) {
+        return
+      }
+
+      const file = files[0]
+
+      if (!isPdfFile(file)) {
+        setSelectedFile(null)
+        setErrorMessage('Only PDF files (.pdf) can be uploaded. Please choose a PDF document.')
+        onFileChange?.(null)
+        return
+      }
+
+      setErrorMessage(null)
+      setSelectedFile(file)
+      onFileChange?.(file)
+    },
+    [onFileChange],
+  )
+
+  const handleInputChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      handleFiles(event.target.files)
+      event.target.value = ''
+    },
+    [handleFiles],
+  )
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault()
+      event.stopPropagation()
+      setIsDragging(false)
+      handleFiles(event.dataTransfer?.files ?? null)
+    },
+    [handleFiles],
+  )
+
+  const handleDragEnter = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    setIsDragging(true)
+  }, [])
+
+  const handleDragOver = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+    event.dataTransfer.dropEffect = 'copy'
+    if (!isDragging) {
+      setIsDragging(true)
+    }
+  }, [isDragging])
+
+  const handleDragLeave = useCallback((event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    event.stopPropagation()
+
+    const nextTarget = event.relatedTarget as Node | null
+    if (nextTarget && event.currentTarget.contains(nextTarget)) {
+      return
+    }
+
+    setIsDragging(false)
+  }, [])
+
+  const handleKeyDown = useCallback((event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      fileInputRef.current?.click()
+    }
+  }, [])
+
+  const describedBy = errorMessage ? `${descriptionId} ${errorId}` : descriptionId
+
+  const dropZoneClasses = `relative flex cursor-pointer flex-col items-center justify-center gap-4 rounded-2xl border-2 border-dashed px-6 py-10 text-center transition duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-400 ${
+    isDragging
+      ? 'border-blue-500 bg-blue-50/80 text-blue-700 shadow-lg shadow-blue-200/60'
+      : 'border-slate-300/80 bg-slate-50/60 text-slate-700 hover:border-blue-500/70 hover:bg-blue-50/50 focus-visible:border-blue-500 focus-visible:bg-blue-50/50'
+  }`
+
+  return (
+    <div className="grid gap-4">
+      <input
+        ref={fileInputRef}
+        id={inputId}
+        type="file"
+        accept="application/pdf"
+        className="sr-only"
+        onChange={handleInputChange}
+      />
+
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label="Upload a PDF document"
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={describedBy}
+        onClick={() => fileInputRef.current?.click()}
+        onKeyDown={handleKeyDown}
+        onDrop={handleDrop}
+        onDragEnter={handleDragEnter}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        className={dropZoneClasses}
+      >
+        <span aria-hidden="true" className="text-4xl">
+          📄
+        </span>
+        <div className="grid gap-1">
+          <p className="text-lg font-semibold text-slate-900">Drag and drop your PDF</p>
+          <p className="text-sm text-slate-600" id={descriptionId}>
+            Drop the locked file here or use the picker below. Only PDF files with the <strong>.pdf</strong> extension are allowed.
+          </p>
+        </div>
+        <span className="inline-flex rounded-full border border-blue-500/40 bg-blue-500/10 px-4 py-1 text-sm font-semibold text-blue-600 shadow-sm">
+          Browse for a PDF
+        </span>
+      </div>
+
+      <div aria-live="polite" id={statusId} className="rounded-2xl border border-slate-200/60 bg-slate-50/80 px-4 py-3 text-sm text-slate-600">
+        {selectedFile ? (
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="min-w-0">
+              <p className="truncate text-sm font-semibold text-slate-900" title={selectedFile.name}>
+                {selectedFile.name}
+              </p>
+              <p className="text-xs text-slate-600">{formatFileSize(selectedFile.size)}</p>
+            </div>
+            <span aria-hidden="true" className="text-xl">
+              ✅
+            </span>
+          </div>
+        ) : (
+          <p>No PDF selected yet.</p>
+        )}
+      </div>
+
+      {errorMessage ? (
+        <p id={errorId} role="alert" className="text-sm font-semibold text-red-600">
+          {errorMessage}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+export default PdfUploader

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -34,6 +34,18 @@ a:focus-visible {
   outline-offset: 3px;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 button {
   font-family: inherit;
 }

--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -3,9 +3,11 @@ import PageSection from '../components/ui/PageSection'
 import Surface from '../components/ui/Surface'
 import CustomerDropdown from '../components/CustomerDropdown'
 import type { QuickBooksCustomer } from '../api'
+import PdfUploader from '../components/PdfUploader'
 
 const UnlockPage: FC = () => {
   const [selectedCustomer, setSelectedCustomer] = useState<QuickBooksCustomer | null>(null)
+  const [selectedPdf, setSelectedPdf] = useState<File | null>(null)
 
   return (
     <PageSection aria-labelledby="unlock-title">
@@ -19,14 +21,21 @@ const UnlockPage: FC = () => {
         </p>
       </Surface>
 
-      <Surface
-        aria-live="polite"
-        role="status"
-        className="grid gap-4 border-dashed border-blue-500/40 bg-gradient-to-br from-blue-500/15 via-blue-400/5 to-blue-300/5"
-      >
-        <p className="text-lg leading-relaxed text-slate-600">
-          The unlocking form is on its way. In the meantime, review the preparation checklist below so you are ready when the
-          uploader arrives.
+      <Surface className="grid gap-5">
+        <div className="grid gap-2">
+          <h2 className="text-xl font-semibold text-slate-900" id="pdf-upload-title">
+            Upload your restricted PDF
+          </h2>
+          <p className="text-base leading-relaxed text-slate-600">
+            Drag and drop your locked document into the area below or browse to choose a file. We currently accept PDF files
+            with the <strong>.pdf</strong> extension only.
+          </p>
+        </div>
+        <PdfUploader ariaLabelledBy="pdf-upload-title" onFileChange={setSelectedPdf} />
+        <p className="text-sm text-slate-600" aria-live="polite">
+          {selectedPdf
+            ? `Ready to unlock ${selectedPdf.name}. Upload a different PDF to replace it.`
+            : 'No PDF uploaded yet. Select a file to begin.'}
         </p>
       </Surface>
 


### PR DESCRIPTION
## Summary
- add a PDF uploader component with drag-and-drop, keyboard activation, and validation for .pdf files
- integrate the uploader into the unlock flow with contextual messaging and status updates
- add a shared sr-only utility class to support accessible hidden form controls

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd5a12b744832fa5fc0caca20ddf59