### PR TITLE
Add test for rejecting JSON payload on docs send endpoint

### DIFF
--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -151,6 +151,16 @@ test('rejects non-PDF input when unlocking a document', async () => {
   }
 });
 
+test('rejects JSON payload when uploading a document', async () => {
+  const { response, body } = await requestJson('/api/docs/send', {
+    method: 'POST',
+    body: JSON.stringify({ customerId: 'cust-123' }),
+  });
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(body, { error: 'Unsupported content type' });
+});
+
 test('uploads a document for sending and returns payment link', async () => {
   const formData = new FormData();
   formData.set('customerId', 'cust-123');


### PR DESCRIPTION
## Summary
- add a node:test case to POST /api/docs/send with JSON to ensure it returns an unsupported content type error

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cda7b349e8832fa43a8a63cd7fd6c2