### PR TITLE
Fix unlock upload field name

### DIFF
--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -5,6 +5,7 @@ import CustomerDropdown from '../components/CustomerDropdown'
 import type { QuickBooksCustomer } from '../api'
 import PdfUploader from '../components/PdfUploader'
 import Button from '../components/ui/Button'
+import { createReviewAndSendFormData } from './createReviewAndSendFormData'
 
 const UnlockPage: FC = () => {
   const [selectedCustomer, setSelectedCustomer] = useState<QuickBooksCustomer | null>(null)
@@ -23,9 +24,7 @@ const UnlockPage: FC = () => {
     setSendError(null)
 
     try {
-      const formData = new FormData()
-      formData.append('file', selectedPdf)
-      formData.append('customerId', selectedCustomer.qbId)
+      const formData = createReviewAndSendFormData(selectedPdf, selectedCustomer.qbId)
 
       const response = await fetch('/api/docs/send', {
         method: 'POST',

--- a/frontend/src/pages/createReviewAndSendFormData.ts
+++ b/frontend/src/pages/createReviewAndSendFormData.ts
@@ -1,0 +1,10 @@
+const createReviewAndSendFormData = (file: File, customerId: string) => {
+  const formData = new FormData()
+  formData.append('document', file)
+  formData.append('customerId', customerId)
+
+  return formData
+}
+
+export default createReviewAndSendFormData
+export { createReviewAndSendFormData }

--- a/frontend/tests/unlockPage.test.js
+++ b/frontend/tests/unlockPage.test.js
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+
+import { createReviewAndSendFormData } from '../dist-test/pages/createReviewAndSendFormData.js'
+
+describe('createReviewAndSendFormData', () => {
+  it('packages the document and customer ID as expected by the API', () => {
+    const file = new File(['example'], 'invoice.pdf', { type: 'application/pdf' })
+    const formData = createReviewAndSendFormData(file, 'qb-42')
+
+    assert.equal(formData.get('document'), file)
+    assert.equal(formData.get('customerId'), 'qb-42')
+    assert.equal(formData.has('file'), false)
+  })
+})


### PR DESCRIPTION
## Summary
- create a helper that builds the Review & Send form data with the `document` field expected by the API
- update the unlock page to use the helper when submitting uploads
- add a node-based test to confirm the helper attaches the PDF under the correct key

## Testing
- npm --prefix frontend test

------
https://chatgpt.com/codex/tasks/task_e_68cdaea9fba4832fb94c6c24fcccc8ba