### PR TITLE
Use button for QuickBooks payment link

### DIFF
--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -169,17 +169,15 @@ const UnlockPage: FC = () => {
         </div>
         <div aria-live="polite" aria-atomic="true" className="grid gap-2">
           {paymentLink ? (
-            <p className="text-sm font-semibold text-emerald-700" role="status">
-              Invoice ready! Share the payment link with your customer:{' '}
-              <a
-                href={paymentLink}
-                target="_blank"
-                rel="noreferrer"
-                className="underline hover:text-emerald-600"
-              >
-                {paymentLink}
-              </a>
-            </p>
+            <div
+              className="flex flex-wrap items-center gap-3 text-sm font-semibold text-emerald-700"
+              role="status"
+            >
+              <span>Invoice ready! Share the payment link with your customer.</span>
+              <Button as="a" href={paymentLink} target="_blank" rel="noreferrer">
+                Pay Now
+              </Button>
+            </div>
           ) : null}
           {sendError ? (
             <p className="text-sm font-semibold text-red-600" role="alert">


### PR DESCRIPTION
## Summary
- replace the payment success link with the shared Button component and "Pay Now" label
- adjust the confirmation message layout to pair the new button with the existing copy

## Testing
- npx eslint src/pages/UnlockPage.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cdb354f190832faf370d5549377d9e