### PR TITLE
Add invoice creation to document send flow

### DIFF
--- a/backend/src/routes/docs.routes.ts
+++ b/backend/src/routes/docs.routes.ts
@@ -9,6 +9,7 @@ import {
   handleDocumentSubmission,
   type UploadedDocument,
 } from '../services/document.service';
+import { createInvoice } from '../services/qb.service';
 
 const router = Router();
 
@@ -319,11 +320,22 @@ router.post('/send', async (req, res) => {
       });
     }
 
-    const result = await handleDocumentSubmission(customerId, file);
+    const submission = await handleDocumentSubmission(customerId, file);
+    const invoice = await createInvoice({
+      customerId,
+      amount: submission.invoice.amount,
+      memo: submission.invoice.memo,
+    });
 
     res.status(200).json({
       message: 'Document sent successfully',
-      paymentLink: result.paymentLink,
+      paymentLink: submission.paymentLink,
+      invoice: {
+        id: invoice.id,
+        amount: invoice.amount,
+        balance: invoice.balance,
+        status: invoice.status,
+      },
     });
   } catch (error) {
     if (error instanceof MultipartParsingError) {

--- a/backend/src/services/document.service.ts
+++ b/backend/src/services/document.service.ts
@@ -2,9 +2,15 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 
+export interface DocumentInvoiceDetails {
+  amount: number;
+  memo: string;
+}
+
 export interface DocumentSubmissionResult {
   storedPath: string;
   paymentLink: string;
+  invoice: DocumentInvoiceDetails;
 }
 
 export interface UploadedDocument {
@@ -29,6 +35,23 @@ function generateStoragePath(customerId: string, originalName: string, timestamp
     .toLowerCase() || 'document';
 
   return path.join(os.tmpdir(), `${customerId}-${timestamp}-${baseName}${ext}`);
+}
+
+const DEFAULT_INVOICE_AMOUNT = 125;
+
+function generateInvoiceMemo(originalName: string) {
+  const ext = path.extname(originalName).toLowerCase() || '.pdf';
+  const baseName = path
+    .basename(originalName, ext)
+    .replace(/[^a-zA-Z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!baseName) {
+    return 'PDF unlock service';
+  }
+
+  return `PDF unlock service for ${baseName}`;
 }
 
 export async function handleDocumentSubmission(
@@ -62,6 +85,13 @@ export async function handleDocumentSubmission(
 
   const paymentLink = `https://payments.example.com/checkout/${customerId}-${timestamp}`;
 
-  return { storedPath: storagePath, paymentLink };
+  return {
+    storedPath: storagePath,
+    paymentLink,
+    invoice: {
+      amount: DEFAULT_INVOICE_AMOUNT,
+      memo: generateInvoiceMemo(file.originalName),
+    },
+  };
 }
 

--- a/backend/tests/app.test.js
+++ b/backend/tests/app.test.js
@@ -176,6 +176,12 @@ test('uploads a document for sending and returns payment link', async () => {
   assert.equal(response.status, 200);
   assert.equal(body.message, 'Document sent successfully');
   assert.match(body.paymentLink, /^https:\/\/payments\.example\.com\//);
+  assert.ok(body.invoice);
+  assert.equal(typeof body.invoice.id, 'string');
+  assert.notEqual(body.invoice.id.length, 0);
+  assert.equal(body.invoice.amount, 125);
+  assert.equal(body.invoice.balance, 125);
+  assert.equal(body.invoice.status, 'OPEN');
 });
 
 test('validates customerId when uploading a document', async () => {


### PR DESCRIPTION
## Summary
- create an invoice via the QuickBooks service after a document submission succeeds and return its details with the payment link
- extend the document service response with invoice payload information for routing logic
- update the docs send integration test to assert the new invoice data

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdb5bd2e4c832fafcf4a137cfeb7e2