### PR TITLE
Add invoice polling to unlock page

### DIFF
--- a/frontend/src/pages/startInvoiceStatusPolling.ts
+++ b/frontend/src/pages/startInvoiceStatusPolling.ts
@@ -1,0 +1,105 @@
+export interface InvoiceStatusPollingOptions {
+  fetchStatus: (signal: AbortSignal) => Promise<string>
+  onStatus: (status: string) => void
+  onError: (error: Error) => void
+  intervalMs?: number
+  timeoutMs?: number
+}
+
+const DEFAULT_POLL_INTERVAL_MS = 5000
+const DEFAULT_TIMEOUT_MS = 2 * 60 * 1000
+
+export const startInvoiceStatusPolling = ({
+  fetchStatus,
+  onStatus,
+  onError,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+}: InvoiceStatusPollingOptions): (() => void) => {
+  let isActive = true
+  let timeoutId: ReturnType<typeof setTimeout> | null = null
+  let latestController: AbortController | null = null
+  const startedAt = Date.now()
+
+  const stop = () => {
+    isActive = false
+
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId)
+      timeoutId = null
+    }
+
+    if (latestController) {
+      latestController.abort()
+      latestController = null
+    }
+  }
+
+  const scheduleNextPoll = () => {
+    if (!isActive) {
+      return
+    }
+
+    timeoutId = setTimeout(() => {
+      timeoutId = null
+      void runPoll()
+    }, intervalMs)
+  }
+
+  const runPoll = async (): Promise<void> => {
+    if (!isActive) {
+      return
+    }
+
+    if (Date.now() - startedAt >= timeoutMs) {
+      stop()
+      onError(new Error('Timed out while waiting for payment confirmation.'))
+      return
+    }
+
+    const controller = new AbortController()
+    latestController = controller
+
+    try {
+      const status = await fetchStatus(controller.signal)
+
+      if (!isActive) {
+        return
+      }
+
+      onStatus(status)
+
+      if (status.toUpperCase() === 'PAID') {
+        stop()
+        return
+      }
+
+      if (Date.now() - startedAt >= timeoutMs) {
+        stop()
+        onError(new Error('Timed out while waiting for payment confirmation.'))
+        return
+      }
+
+      scheduleNextPoll()
+    } catch (error) {
+      if (!isActive) {
+        return
+      }
+
+      if (error instanceof DOMException && error.name === 'AbortError') {
+        return
+      }
+
+      stop()
+      const normalizedError =
+        error instanceof Error ? error : new Error('Unable to fetch the invoice status.')
+      onError(normalizedError)
+    }
+  }
+
+  void runPoll()
+
+  return () => {
+    stop()
+  }
+}

--- a/frontend/tests/startInvoiceStatusPolling.test.js
+++ b/frontend/tests/startInvoiceStatusPolling.test.js
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
+import { setTimeout as delay } from 'node:timers/promises'
+import { startInvoiceStatusPolling } from '../dist-test/pages/startInvoiceStatusPolling.js'
+
+describe('startInvoiceStatusPolling', () => {
+  it('polls until the invoice status is PAID', async () => {
+    const statuses = ['SENT', 'PARTIALLY_PAID', 'PAID']
+    const observed = []
+    let receivedError = null
+
+    startInvoiceStatusPolling({
+      fetchStatus: async () => statuses.shift() ?? 'PAID',
+      onStatus: (status) => {
+        observed.push(status)
+      },
+      onError: (error) => {
+        receivedError = error
+      },
+      intervalMs: 0,
+      timeoutMs: 100,
+    })
+
+    for (let attempt = 0; attempt < 10 && observed[observed.length - 1] !== 'PAID'; attempt += 1) {
+      await delay(10)
+    }
+
+    assert.deepEqual(observed, ['SENT', 'PARTIALLY_PAID', 'PAID'])
+    assert.equal(receivedError, null)
+  })
+
+  it('stops polling when cleanup is invoked', async () => {
+    let calls = 0
+
+    const stop = startInvoiceStatusPolling({
+      fetchStatus: async () => {
+        calls += 1
+        return 'SENT'
+      },
+      onStatus: () => {},
+      onError: () => {},
+      intervalMs: 0,
+      timeoutMs: 100,
+    })
+
+    await delay(5)
+    stop()
+    const callsAfterCleanup = calls
+
+    await delay(20)
+
+    assert.equal(calls, callsAfterCleanup)
+  })
+
+  it('reports an error when polling times out', async () => {
+    let receivedError = null
+
+    startInvoiceStatusPolling({
+      fetchStatus: async () => 'SENT',
+      onStatus: () => {},
+      onError: (error) => {
+        receivedError = error
+      },
+      intervalMs: 5,
+      timeoutMs: 15,
+    })
+
+    await delay(40)
+
+    assert(receivedError instanceof Error)
+    assert.equal(receivedError?.message, 'Timed out while waiting for payment confirmation.')
+  })
+})

--- a/frontend/tests/unlockPage.test.js
+++ b/frontend/tests/unlockPage.test.js
@@ -24,7 +24,8 @@ describe('parseServerErrorMessage', () => {
 
   it('returns null for invalid JSON payloads', () => {
     assert.equal(parseServerErrorMessage('{ invalid'), null)
-
+  })
+})
 
 describe('createReviewAndSendFormData', () => {
   it('packages the document and customer ID as expected by the API', () => {


### PR DESCRIPTION
## Summary
- capture the invoice ID returned by the send API, start polling for invoice status updates, and surface waiting/success messaging on the unlock page
- introduce a reusable helper to manage invoice status polling with abort, timeout, and error handling
- add node:test coverage for the polling logic and tidy the existing unlock page test suite

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cdb6fe33d0832f88dad8991dea1a0d