### PR TITLE
Switch frontend to PDF Lock flow

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>PDF Unlock</title>
+    <title>PDF Lock</title>
     <script>
       window.tailwind = window.tailwind || {}
       window.tailwind.config = {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,12 +14,12 @@ type RouteDefinition = {
 
 const routes: RouteDefinition[] = [
   { path: '/', label: 'Home', element: <HomePage /> },
-  { path: '/unlock', label: 'Lock', element: <LockPage /> },
+  { path: '/lock', label: 'Lock', element: <LockPage /> },
   { path: '/about', label: 'About', element: <AboutPage /> },
 ]
 
 function App() {
-  const { path, navigate } = useHashRouter()
+  const { path, rawPath, navigate } = useHashRouter()
 
   const activeRoute = useMemo(
     () => routes.find((route) => route.path === path),
@@ -27,12 +27,18 @@ function App() {
   )
 
   useEffect(() => {
+    if (rawPath === '/unlock') {
+      navigate('/lock')
+    }
+  }, [rawPath, navigate])
+
+  useEffect(() => {
     if (typeof document === 'undefined') {
       return
     }
 
     const pageLabel = activeRoute?.label ?? 'Not found'
-    document.title = `${pageLabel} | PDF Unlock`
+    document.title = `${pageLabel} | PDF Lock`
   }, [activeRoute])
 
   const mainContent = activeRoute?.element ?? (
@@ -54,12 +60,12 @@ function App() {
         <a
           className="inline-flex items-center gap-2 text-lg font-semibold uppercase tracking-[0.12em] text-slate-50 transition-transform duration-150 hover:-translate-y-0.5"
           href="#/"
-          aria-label="PDF Unlock home"
+          aria-label="PDF Lock home"
         >
           <span className="text-2xl" aria-hidden="true">
-            🔓
+            🔒
           </span>
-          <span className="hidden text-sm tracking-[0.3em] sm:inline">PDF Unlock</span>
+          <span className="hidden text-sm tracking-[0.3em] sm:inline">PDF Lock</span>
         </a>
         <nav className="ml-auto" aria-label="Primary">
           <ul className="flex flex-wrap items-center gap-3">
@@ -89,7 +95,7 @@ function App() {
         <div className="w-full max-w-5xl">{mainContent}</div>
       </main>
       <footer className="border-t border-slate-200/60 bg-white/80 px-4 py-6 text-center text-sm text-slate-500 shadow-inner sm:px-8 lg:px-12">
-        <p>© {currentYear} PDF Unlock. All rights reserved.</p>
+        <p>© {currentYear} PDF Lock. All rights reserved.</p>
       </footer>
     </div>
   )

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -9,31 +9,32 @@ const AboutPage: FC = () => (
         Built for secure document collaboration
       </h1>
       <p className="text-base leading-relaxed text-slate-600">
-        The PDF Unlock project focuses on transparent tooling for handling sensitive files. We believe removing restrictions
-        should be simple, auditable, and respectful of the people who own the documents.
+        PDF Lock provides a reliable way to add password protection to invoices and statements before they leave your business.
+        Every interaction is designed to be transparent, auditable, and respectful of the people who trust you with their
+        information.
       </p>
     </Surface>
 
     <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
       <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">Why unlock PDFs?</h2>
+        <h2 className="text-xl font-semibold text-slate-900">Why lock PDFs?</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          Password-protected documents help keep information secure, yet the same controls can slow down collaboration. Providing
-          a safe, user-friendly way to remove those locks keeps teams moving without compromising trust.
+          Finance teams need a simple way to share statements without exposing sensitive data. PDF Lock encrypts files, sends the
+          password automatically, and confirms delivery only after payment is complete.
         </p>
       </Surface>
       <Surface as="article" role="listitem" className="grid gap-4">
         <h2 className="text-xl font-semibold text-slate-900">What to expect next</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          Upcoming iterations will introduce role-based access, audit logs for every unlock operation, and automated clean-up
-          routines so you can meet internal compliance goals.
+          Upcoming iterations will introduce role-based access, detailed audit logs for each password delivery, and automated
+          retention policies so you can meet internal compliance goals.
         </p>
       </Surface>
       <Surface as="article" role="listitem" className="grid gap-4">
         <h2 className="text-xl font-semibold text-slate-900">How to contribute</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          We are actively drafting the core unlocking workflow. Share feedback, report issues, or suggest integrations to help
-          shape the roadmap and make the tool fit real-world teams.
+          We are actively expanding the locking workflow. Share feedback, report issues, or suggest integrations to help shape
+          the roadmap and make the tool fit real-world teams.
         </p>
       </Surface>
     </div>

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -6,42 +6,41 @@ import Surface from '../components/ui/Surface'
 const HomePage: FC = () => (
   <PageSection aria-labelledby="home-title">
     <Surface className="grid gap-5 bg-gradient-to-br from-blue-600/15 via-blue-500/10 to-blue-500/5">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">PDF Unlock</p>
+      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">PDF Lock</p>
       <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="home-title">
-        Effortless PDF unlocking for every workflow
+        Password-protect PDFs in one guided flow
       </h1>
       <p className="text-lg leading-relaxed text-slate-600">
-        Securely remove passwords and usage restrictions from your PDF documents. Upload a file, choose the unlock options that
-        fit your needs, and download the document in seconds.
+        Upload a document, confirm the QuickBooks customer who should receive it, and generate a strong password before the PDF
+        is delivered. PDF Lock keeps sensitive files protected until payment is complete.
       </p>
       <div className="flex flex-wrap items-center gap-3">
-        <Button as="a" href="#/unlock">
-          Start unlocking
+        <Button as="a" href="#/lock">
+          Start locking
         </Button>
         <Button as="a" href="#/about" variant="secondary">
-          Learn about the project
+          Learn how PDF Lock works
         </Button>
       </div>
     </Surface>
 
     <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
       <Surface as="article" role="listitem" className="grid gap-3">
-        <h2 className="text-xl font-semibold text-slate-900">Privacy first</h2>
+        <h2 className="text-xl font-semibold text-slate-900">Strong protection</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          Files stay on your device while we prepare the unlocking workflow. Nothing is stored on external servers.
+          We generate complex passwords, encrypt the PDF, and surface the credentials only after the invoice is paid.
         </p>
       </Surface>
       <Surface as="article" role="listitem" className="grid gap-3">
         <h2 className="text-xl font-semibold text-slate-900">Guided experience</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          Step-by-step prompts walk you through decrypting a file, making the process approachable even if you are new to PDFs.
+          Step-by-step prompts keep you informed while we upload the file, confirm customer details, and secure the document.
         </p>
       </Surface>
       <Surface as="article" role="listitem" className="grid gap-3">
-        <h2 className="text-xl font-semibold text-slate-900">Productivity ready</h2>
+        <h2 className="text-xl font-semibold text-slate-900">Compliance ready</h2>
         <p className="text-base leading-relaxed text-slate-600">
-          Coming soon: integrations with your favourite cloud providers to streamline team workflows and archive unlocked
-          documents automatically.
+          Designed for audit trails and retention policies, so your team can share protected PDFs without sacrificing oversight.
         </p>
       </Surface>
     </div>

--- a/frontend/tests/useHashRouter.test.js
+++ b/frontend/tests/useHashRouter.test.js
@@ -63,7 +63,12 @@ describe('normalizePath', () => {
   })
 
   it('ensures the path includes a leading slash', () => {
-    assert.equal(normalizePath('unlock'), '/unlock')
+    assert.equal(normalizePath('lock'), '/lock')
+  })
+
+  it('maps the legacy unlock route to the lock route', () => {
+    assert.equal(normalizePath('unlock'), '/lock')
+    assert.equal(normalizePath('#/unlock'), '/lock')
   })
 
   it('removes leading hash fragments', () => {
@@ -82,10 +87,10 @@ describe('getHashPath', () => {
   })
 
   it('normalizes the current hash from the window', () => {
-    const mockWindow = createMockWindow('#/unlock')
+    const mockWindow = createMockWindow('#/lock')
     globalThis.window = mockWindow
 
-    assert.equal(getHashPath(), '/unlock')
+    assert.equal(getHashPath(), '/lock')
   })
 })
 
@@ -103,9 +108,19 @@ describe('applyHashNavigation', () => {
   })
 
   it('normalizes and updates the hash location', () => {
-    applyHashNavigation('unlock')
+    applyHashNavigation('lock')
 
-    assert.equal(mockWindow.getHash(), '#/unlock')
+    assert.equal(mockWindow.getHash(), '#/lock')
+    assert.equal(mockWindow.getWriteCount(), 1)
+  })
+
+  it('redirects legacy unlock hashes to the lock route', () => {
+    mockWindow.location.hash = '#/unlock'
+    mockWindow.resetWriteCount()
+
+    applyHashNavigation('/unlock')
+
+    assert.equal(mockWindow.getHash(), '#/lock')
     assert.equal(mockWindow.getWriteCount(), 1)
   })
 

--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "https://pdf-unlock.vercel.app/api/$1"
+      "destination": "https://pdf-lock.vercel.app/api/$1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update the SPA routes to serve a `/lock` flow, retitle the chrome to PDF Lock, and guard legacy `#/unlock` hashes
- canonicalize hash navigation so legacy unlock URLs resolve to the lock route and expose the raw hash for redirect handling
- refresh the home/about marketing copy and static config to reflect PDF Lock branding
- align navigation tests with the `/lock` route and cover the unlock-to-lock redirect

## Testing
- npm test --no-progress

------
https://chatgpt.com/codex/tasks/task_e_68d0abdc80c4832f9edd178f977b9467