### PR TITLE
Add translation support and localize UI text

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import { useEffect, useMemo } from 'react'
+import { useTranslations, type MessageKey } from './i18n/useTranslations.js'
 import { useHashRouter } from './hooks/useHashRouter'
 import AboutPage from './pages/AboutPage'
 import HomePage from './pages/HomePage'
@@ -8,18 +9,19 @@ import LockPage from './pages/LockPage'
 
 type RouteDefinition = {
   path: string
-  label: string
+  labelKey: MessageKey
   element: ReactNode
 }
 
 const routes: RouteDefinition[] = [
-  { path: '/', label: 'Home', element: <HomePage /> },
-  { path: '/lock', label: 'Lock', element: <LockPage /> },
-  { path: '/about', label: 'About', element: <AboutPage /> },
+  { path: '/', labelKey: 'nav.home', element: <HomePage /> },
+  { path: '/lock', labelKey: 'nav.lock', element: <LockPage /> },
+  { path: '/about', labelKey: 'nav.about', element: <AboutPage /> },
 ]
 
 function App() {
   const { path, rawPath, navigate } = useHashRouter()
+  const { t } = useTranslations()
 
   const activeRoute = useMemo(
     () => routes.find((route) => route.path === path),
@@ -37,9 +39,12 @@ function App() {
       return
     }
 
-    const pageLabel = activeRoute?.label ?? 'Not found'
-    document.title = `${pageLabel} | PDF Lock`
-  }, [activeRoute])
+    const pageLabel = activeRoute ? t(activeRoute.labelKey) : t('app.notFound')
+    document.title = t('app.documentTitle', {
+      page: pageLabel,
+      brand: t('brand.name'),
+    })
+  }, [activeRoute, t])
 
   const mainContent = activeRoute?.element ?? (
     <NotFoundPage onNavigateHome={() => navigate('/')} />
@@ -47,6 +52,7 @@ function App() {
   const currentYear = new Date().getFullYear()
   const navLinkBase =
     'inline-flex items-center justify-center rounded-full px-4 py-2 text-sm font-medium transition duration-150 hover:-translate-y-0.5 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-yellow-300 md:px-5'
+  const brandName = t('brand.name')
 
   return (
     <div className="relative flex min-h-screen flex-col bg-gradient-to-b from-slate-200 via-slate-50 to-white text-slate-900">
@@ -54,20 +60,20 @@ function App() {
         className="absolute left-4 top-4 -translate-x-[120%] -translate-y-[120%] rounded-full bg-blue-600 px-4 py-2 font-semibold text-slate-50 shadow-lg shadow-blue-600/40 transition-transform duration-150 focus-visible:translate-x-0 focus-visible:translate-y-0 focus-visible:outline-none"
         href="#main-content"
       >
-        Skip to main content
+        {t('app.skipToContent')}
       </a>
       <header className="sticky top-0 z-50 flex flex-wrap items-center justify-between gap-6 bg-slate-900/95 px-6 py-4 text-slate-50 shadow-lg shadow-slate-900/30 backdrop-blur sm:px-10">
         <a
           className="inline-flex items-center gap-2 text-lg font-semibold uppercase tracking-[0.12em] text-slate-50 transition-transform duration-150 hover:-translate-y-0.5"
           href="#/"
-          aria-label="PDF Lock home"
+          aria-label={t('nav.homeAria', { brand: brandName })}
         >
           <span className="text-2xl" aria-hidden="true">
             🔒
           </span>
-          <span className="hidden text-sm tracking-[0.3em] sm:inline">PDF Lock</span>
+          <span className="hidden text-sm tracking-[0.3em] sm:inline">{brandName}</span>
         </a>
-        <nav className="ml-auto" aria-label="Primary">
+        <nav className="ml-auto" aria-label={t('nav.primaryLabel')}>
           <ul className="flex flex-wrap items-center gap-3">
             {routes.map((route) => (
               <li key={route.path}>
@@ -80,7 +86,7 @@ function App() {
                   }`}
                   aria-current={path === route.path ? 'page' : undefined}
                 >
-                  {route.label}
+                  {t(route.labelKey)}
                 </a>
               </li>
             ))}
@@ -95,7 +101,9 @@ function App() {
         <div className="w-full max-w-5xl">{mainContent}</div>
       </main>
       <footer className="border-t border-slate-200/60 bg-white/80 px-4 py-6 text-center text-sm text-slate-500 shadow-inner sm:px-8 lg:px-12">
-        <p>© {currentYear} PDF Lock. All rights reserved.</p>
+        <p>
+          © {currentYear} {brandName}. {t('app.footer.rights')}
+        </p>
       </footer>
     </div>
   )

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -1,0 +1,109 @@
+const messages = {
+  'brand.name': 'PDF Lock',
+  'brand.tagline': 'Password-protect PDFs in one guided flow',
+
+  'app.skipToContent': 'Skip to main content',
+  'app.notFound': 'Not found',
+  'app.documentTitle': '{page} | {brand}',
+  'app.footer.rights': 'All rights reserved.',
+
+  'nav.home': 'Home',
+  'nav.lock': 'Lock',
+  'nav.about': 'About',
+  'nav.homeAria': '{brand} home',
+  'nav.primaryLabel': 'Primary',
+
+  'home.title': 'Password-protect PDFs in one guided flow',
+  'home.description':
+    'Upload a document, confirm the QuickBooks customer who should receive it, and generate a strong password before the PDF is delivered. {brand} keeps sensitive files protected until payment is complete.',
+  'home.ctaPrimary': 'Start locking',
+  'home.ctaSecondary': 'Learn how {brand} works',
+  'home.strongProtection.title': 'Strong protection',
+  'home.strongProtection.copy':
+    'We generate complex passwords, encrypt the PDF, and surface the credentials only after the invoice is paid.',
+  'home.guidedExperience.title': 'Guided experience',
+  'home.guidedExperience.copy':
+    'Step-by-step prompts keep you informed while we upload the file, confirm customer details, and secure the document.',
+  'home.complianceReady.title': 'Compliance ready',
+  'home.complianceReady.copy':
+    'Designed for audit trails and retention policies, so your team can share protected PDFs without sacrificing oversight.',
+
+  'about.title': 'Built for secure document collaboration',
+  'about.description':
+    '{brand} provides a reliable way to add password protection to invoices and statements before they leave your business. Every interaction is designed to be transparent, auditable, and respectful of the people who trust you with their information.',
+  'about.why.title': 'Why lock PDFs?',
+  'about.why.copy':
+    'Finance teams need a simple way to share statements without exposing sensitive data. {brand} encrypts files, sends the password automatically, and confirms delivery only after payment is complete.',
+  'about.expect.title': 'What to expect next',
+  'about.expect.copy':
+    'Upcoming iterations will introduce role-based access, detailed audit logs for each password delivery, and automated retention policies so you can meet internal compliance goals.',
+  'about.contribute.title': 'How to contribute',
+  'about.contribute.copy':
+    'We are actively expanding the locking workflow. Share feedback, report issues, or suggest integrations to help shape the roadmap and make the tool fit real-world teams.',
+
+  'lock.title': 'Lock PDF with Password',
+  'lock.description':
+    'Protect your PDF with a strong, system-generated password. Upload the document, confirm the customer who should receive it, and we will deliver secure access after payment is confirmed.',
+  'lock.upload.title': 'Upload the PDF to protect',
+  'lock.upload.description':
+    'Drag and drop the PDF you want to secure into the area below or browse to choose a file. We currently accept PDF files with the <strong>.pdf</strong> extension only.',
+  'lock.upload.ready': 'Ready to lock {fileName}. Upload a different PDF to replace it.',
+  'lock.upload.empty': 'No PDF uploaded yet. Select a file to begin.',
+  'lock.customer.title': 'QuickBooks customer lookup',
+  'lock.customer.description':
+    'Search your connected QuickBooks customers to send the locked document to the right account. Start typing a name or email address to filter the list.',
+  'lock.customer.selectorLabel': 'Select a customer',
+  'lock.customer.selectorPlaceholder': 'Start typing a customer name or email…',
+  'lock.customer.selectorHelper':
+    'Customers sync from QuickBooks automatically. Narrow the search to find the right match quickly.',
+  'lock.customer.selected':
+    'Selected {customerName} ({customerEmail}). They will receive the payment email and password.',
+  'lock.customer.empty':
+    'No customer selected yet. Choose who should receive the locked PDF.',
+  'lock.passwordToggle.label': 'Lock with password',
+  'lock.passwordToggle.helper':
+    'Encrypts the PDF with a system-generated password before it is sent to your customer.',
+  'lock.passwordToggle.ariaLabel': 'Learn how locking with a password works',
+  'lock.passwordToggle.tooltip':
+    'We generate a strong password, email it to your customer, and display it here after payment.',
+  'lock.requiredToggleMessage': 'Enable password protection to continue.',
+  'lock.preparation.title': 'Preparation checklist',
+  'lock.preparation.confirm':
+    'Confirm who should receive the locked PDF once payment clears.',
+  'lock.preparation.inform': 'Let your customer know a unique password will arrive in their inbox.',
+  'lock.preparation.review':
+    'Review your retention policies for storing the encrypted document and password.',
+  'lock.nextSteps.title': 'What happens next?',
+  'lock.nextSteps.description':
+    'We will guide you through uploading the file, generating the secure password, and collecting payment. After the invoice is paid, we email the password to your customer and display it below for quick reference.',
+  'lock.cta': 'Lock & Generate Payment Link',
+  'lock.progress': 'Locking PDF and creating payment link…',
+  'lock.helper':
+    'We will generate a payment link, lock the PDF, and share the password automatically.',
+  'lock.helper.select': 'Select a PDF and customer to enable locking.',
+  'lock.helper.enable':
+    'Enable password protection, then select a PDF and customer to continue.',
+  'lock.paymentLinkReady':
+    'Payment link ready. Share it with your customer to confirm the order.',
+  'lock.payNow': 'Pay Now',
+  'lock.waiting': 'Waiting for payment confirmation…',
+  'lock.success':
+    'Payment confirmed. Password sent to the customer and available below.',
+  'lock.passwordHeader': 'Password',
+  'lock.passwordSubheader':
+    'Store this password securely. It has also been emailed to the customer.',
+  'lock.error.requestFailed': 'Request failed with status {status}',
+  'lock.error.invalidResponse': 'Received an invalid response from the server.',
+  'lock.error.missingPaymentLink': 'The server response did not include a payment link.',
+  'lock.error.missingInvoiceId': 'The server response did not include an invoice ID.',
+  'lock.error.missingInvoiceStatus': 'The server response did not include an invoice status.',
+  'lock.error.invalidInvoiceStatusResponse':
+    'Received an invalid response while checking the invoice status.',
+  'lock.error.sendFailed': 'Unable to send the document.',
+  'lock.error.statusFailed': 'Unable to fetch the invoice status.',
+} as const
+
+export type Messages = typeof messages
+export type MessageKey = keyof Messages
+
+export default messages

--- a/frontend/src/i18n/useTranslations.ts
+++ b/frontend/src/i18n/useTranslations.ts
@@ -1,0 +1,46 @@
+import { useCallback } from 'react'
+import messages, { type MessageKey } from './messages.js'
+
+export type TranslationValues = Record<string, string | number | boolean>
+
+const TOKEN_PATTERN = /\{(\w+)\}/g
+
+export const translate = (
+  key: MessageKey,
+  replacements?: TranslationValues,
+): string => {
+  const template = messages[key]
+
+  if (!template) {
+    return key
+  }
+
+  if (!replacements) {
+    return template
+  }
+
+  return template.replace(TOKEN_PATTERN, (match, token) => {
+    if (!(token in replacements)) {
+      return match
+    }
+
+    const value = replacements[token]
+
+    if (value === undefined || value === null) {
+      return match
+    }
+
+    return String(value)
+  })
+}
+
+export const useTranslations = () => {
+  const t = useCallback(
+    (key: MessageKey, replacements?: TranslationValues) => translate(key, replacements),
+    [],
+  )
+
+  return { t }
+}
+
+export type { MessageKey }

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,44 +1,41 @@
 import type { FC } from 'react'
 import PageSection from '../components/ui/PageSection'
 import Surface from '../components/ui/Surface'
+import { useTranslations } from '../i18n/useTranslations.js'
 
-const AboutPage: FC = () => (
-  <PageSection aria-labelledby="about-title">
-    <Surface className="grid gap-4">
-      <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="about-title">
-        Built for secure document collaboration
-      </h1>
-      <p className="text-base leading-relaxed text-slate-600">
-        PDF Lock provides a reliable way to add password protection to invoices and statements before they leave your business.
-        Every interaction is designed to be transparent, auditable, and respectful of the people who trust you with their
-        information.
-      </p>
-    </Surface>
+const AboutPage: FC = () => {
+  const { t } = useTranslations()
+  const brandName = t('brand.name')
 
-    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
-      <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">Why lock PDFs?</h2>
+  return (
+    <PageSection aria-labelledby="about-title">
+      <Surface className="grid gap-4">
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="about-title">
+          {t('about.title')}
+        </h1>
         <p className="text-base leading-relaxed text-slate-600">
-          Finance teams need a simple way to share statements without exposing sensitive data. PDF Lock encrypts files, sends the
-          password automatically, and confirms delivery only after payment is complete.
+          {t('about.description', { brand: brandName })}
         </p>
       </Surface>
-      <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">What to expect next</h2>
-        <p className="text-base leading-relaxed text-slate-600">
-          Upcoming iterations will introduce role-based access, detailed audit logs for each password delivery, and automated
-          retention policies so you can meet internal compliance goals.
-        </p>
-      </Surface>
-      <Surface as="article" role="listitem" className="grid gap-4">
-        <h2 className="text-xl font-semibold text-slate-900">How to contribute</h2>
-        <p className="text-base leading-relaxed text-slate-600">
-          We are actively expanding the locking workflow. Share feedback, report issues, or suggest integrations to help shape
-          the roadmap and make the tool fit real-world teams.
-        </p>
-      </Surface>
-    </div>
-  </PageSection>
-)
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
+        <Surface as="article" role="listitem" className="grid gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">{t('about.why.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">
+            {t('about.why.copy', { brand: brandName })}
+          </p>
+        </Surface>
+        <Surface as="article" role="listitem" className="grid gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">{t('about.expect.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">{t('about.expect.copy')}</p>
+        </Surface>
+        <Surface as="article" role="listitem" className="grid gap-4">
+          <h2 className="text-xl font-semibold text-slate-900">{t('about.contribute.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">{t('about.contribute.copy')}</p>
+        </Surface>
+      </div>
+    </PageSection>
+  )
+}
 
 export default AboutPage

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -2,49 +2,48 @@ import type { FC } from 'react'
 import Button from '../components/ui/Button'
 import PageSection from '../components/ui/PageSection'
 import Surface from '../components/ui/Surface'
+import { useTranslations } from '../i18n/useTranslations.js'
 
-const HomePage: FC = () => (
-  <PageSection aria-labelledby="home-title">
-    <Surface className="grid gap-5 bg-gradient-to-br from-blue-600/15 via-blue-500/10 to-blue-500/5">
-      <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">PDF Lock</p>
-      <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="home-title">
-        Password-protect PDFs in one guided flow
-      </h1>
-      <p className="text-lg leading-relaxed text-slate-600">
-        Upload a document, confirm the QuickBooks customer who should receive it, and generate a strong password before the PDF
-        is delivered. PDF Lock keeps sensitive files protected until payment is complete.
-      </p>
-      <div className="flex flex-wrap items-center gap-3">
-        <Button as="a" href="#/lock">
-          Start locking
-        </Button>
-        <Button as="a" href="#/about" variant="secondary">
-          Learn how PDF Lock works
-        </Button>
+const HomePage: FC = () => {
+  const { t } = useTranslations()
+  const brandName = t('brand.name')
+
+  return (
+    <PageSection aria-labelledby="home-title">
+      <Surface className="grid gap-5 bg-gradient-to-br from-blue-600/15 via-blue-500/10 to-blue-500/5">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-blue-600">{brandName}</p>
+        <h1 className="text-3xl font-bold tracking-tight text-slate-900 sm:text-4xl" id="home-title">
+          {t('home.title')}
+        </h1>
+        <p className="text-lg leading-relaxed text-slate-600">
+          {t('home.description', { brand: brandName })}
+        </p>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button as="a" href="#/lock">
+            {t('home.ctaPrimary')}
+          </Button>
+          <Button as="a" href="#/about" variant="secondary">
+            {t('home.ctaSecondary', { brand: brandName })}
+          </Button>
+        </div>
+      </Surface>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
+        <Surface as="article" role="listitem" className="grid gap-3">
+          <h2 className="text-xl font-semibold text-slate-900">{t('home.strongProtection.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">{t('home.strongProtection.copy')}</p>
+        </Surface>
+        <Surface as="article" role="listitem" className="grid gap-3">
+          <h2 className="text-xl font-semibold text-slate-900">{t('home.guidedExperience.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">{t('home.guidedExperience.copy')}</p>
+        </Surface>
+        <Surface as="article" role="listitem" className="grid gap-3">
+          <h2 className="text-xl font-semibold text-slate-900">{t('home.complianceReady.title')}</h2>
+          <p className="text-base leading-relaxed text-slate-600">{t('home.complianceReady.copy')}</p>
+        </Surface>
       </div>
-    </Surface>
-
-    <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3" role="list">
-      <Surface as="article" role="listitem" className="grid gap-3">
-        <h2 className="text-xl font-semibold text-slate-900">Strong protection</h2>
-        <p className="text-base leading-relaxed text-slate-600">
-          We generate complex passwords, encrypt the PDF, and surface the credentials only after the invoice is paid.
-        </p>
-      </Surface>
-      <Surface as="article" role="listitem" className="grid gap-3">
-        <h2 className="text-xl font-semibold text-slate-900">Guided experience</h2>
-        <p className="text-base leading-relaxed text-slate-600">
-          Step-by-step prompts keep you informed while we upload the file, confirm customer details, and secure the document.
-        </p>
-      </Surface>
-      <Surface as="article" role="listitem" className="grid gap-3">
-        <h2 className="text-xl font-semibold text-slate-900">Compliance ready</h2>
-        <p className="text-base leading-relaxed text-slate-600">
-          Designed for audit trails and retention policies, so your team can share protected PDFs without sacrificing oversight.
-        </p>
-      </Surface>
-    </div>
-  </PageSection>
-)
+    </PageSection>
+  )
+}
 
 export default HomePage

--- a/frontend/tests/lockPage.test.js
+++ b/frontend/tests/lockPage.test.js
@@ -5,7 +5,16 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { ApiProvider } from '../dist-test/api/ApiProvider.js'
 import { parseServerErrorMessage } from '../dist-test/utils/parseServerErrorMessage.js'
 import { createReviewAndSendFormData } from '../dist-test/pages/createReviewAndSendFormData.js'
+import { translate } from '../dist-test/i18n/useTranslations.js'
 import LockPage from '../dist-test/pages/LockPage.js'
+
+const escapeHtml = (value) =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
 
 describe('parseServerErrorMessage', () => {
   it('returns the message field when provided', () => {
@@ -46,9 +55,17 @@ describe('LockPage messaging', () => {
   it('renders the locking flow copy and disabled action when password protection is off', () => {
     const markup = renderToStaticMarkup(createElement(ApiProvider, {}, createElement(LockPage)))
 
-    assert.match(markup, /Lock PDF with Password/)
-    assert.match(markup, /Lock &amp; Generate Payment Link/)
-    assert.match(markup, /Enable password protection to continue\./)
+    const expectTranslation = (key) => {
+      const message = escapeHtml(translate(key))
+      assert.ok(
+        markup.includes(message),
+        `expected markup to include translation for ${key}`,
+      )
+    }
+
+    expectTranslation('lock.title')
+    expectTranslation('lock.cta')
+    expectTranslation('lock.requiredToggleMessage')
     assert.ok(/<button[^>]+disabled/.test(markup), 'expected the submit button to be disabled by default')
   })
 })


### PR DESCRIPTION
## Summary
- add an i18n message catalog and translation helper hook
- migrate App, LockPage, HomePage, and AboutPage to use translated strings instead of literals
- update LockPage test expectations to reference translated output

## Testing
- `./node_modules/.bin/tsc -p tsconfig.test.json`
- `node --test tests`


------
https://chatgpt.com/codex/tasks/task_e_68d0ae91b3b4832fabd9473e00f42c0b