### PR TITLE
Update frontend Node engine requirement

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
-  "engines": { "node": ">=20.19 <21 || >=22.12" },
+  "engines": { "node": ">=18.18.0" },
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",


### PR DESCRIPTION
## Summary
- broaden the frontend package Node engine requirement to >=18.18.0 so it matches Vercel supported runtimes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d0b2656fe0832fa91b03c1d6fa52db