### PR TITLE
Update lock endpoint test to upload file

### DIFF
--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -89,6 +89,7 @@ const messages = {
     'Lock endpoint succeeded. Output saved to {outputPath}.',
   'lock.testSuccess': 'Lock endpoint succeeded.',
   'lock.testError': 'Unable to complete the lock endpoint test.',
+  'lock.error.missingTestDocument': 'Select a PDF before testing the lock endpoint.',
   'lock.paymentLinkReady':
     'Payment link ready. Share it with your customer to confirm the order.',
   'lock.payNow': 'Pay Now',

--- a/frontend/tests/lockPage.test.js
+++ b/frontend/tests/lockPage.test.js
@@ -6,7 +6,7 @@ import { ApiProvider } from '../dist-test/api/ApiProvider.js'
 import { parseServerErrorMessage } from '../dist-test/utils/parseServerErrorMessage.js'
 import { createReviewAndSendFormData } from '../dist-test/pages/createReviewAndSendFormData.js'
 import { translate } from '../dist-test/i18n/useTranslations.js'
-import LockPage from '../dist-test/pages/LockPage.js'
+import LockPage, { createLockTestFormData } from '../dist-test/pages/LockPage.js'
 
 const escapeHtml = (value) =>
   value
@@ -48,6 +48,17 @@ describe('createReviewAndSendFormData', () => {
     assert.equal(formData.get('document'), file)
     assert.equal(formData.get('customerId'), 'qb-42')
     assert.equal(formData.has('file'), false)
+  })
+})
+
+describe('createLockTestFormData', () => {
+  it('includes the PDF and lock options used for testing the endpoint', () => {
+    const file = new File(['example'], 'sample.pdf', { type: 'application/pdf' })
+    const formData = createLockTestFormData(file)
+
+    assert.equal(formData.get('document'), file)
+    assert.equal(formData.get('password'), 'sample-password')
+    assert.equal(formData.get('download'), 'true')
   })
 })
 


### PR DESCRIPTION
## Summary
- require a selected PDF before invoking the lock endpoint test and share a clear error when missing
- send the uploaded PDF to the lock endpoint with multipart form data and handle JSON or binary responses
- expose a helper for building the lock test form data and cover it with a unit test

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d4a7a3dd50832fb0a60fcfbb077ae6