### PR TITLE
Trigger lock endpoint test download and update messaging

### DIFF
--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -85,9 +85,7 @@ const messages = {
     'Enable password protection, then select a PDF and customer to continue.',
   'lock.testButton': 'Test lock endpoint',
   'lock.testProgress': 'Testing lock endpoint…',
-  'lock.testSuccessWithOutput':
-    'Lock endpoint succeeded. Output saved to {outputPath}.',
-  'lock.testSuccess': 'Lock endpoint succeeded.',
+  'lock.testSuccess': 'Lock endpoint succeeded. Downloading the locked PDF…',
   'lock.testError': 'Unable to complete the lock endpoint test.',
   'lock.error.missingTestDocument': 'Select a PDF before testing the lock endpoint.',
   'lock.paymentLinkReady':

--- a/frontend/tests/lockPage.test.js
+++ b/frontend/tests/lockPage.test.js
@@ -58,7 +58,6 @@ describe('createLockTestFormData', () => {
 
     assert.equal(formData.get('document'), file)
     assert.equal(formData.get('password'), 'sample-password')
-    assert.equal(formData.get('download'), 'true')
   })
 })
 


### PR DESCRIPTION
## Summary
- remove the unused download flag from the lock endpoint test form data
- trigger a PDF download when testing the lock endpoint and update the success copy
- align the lock page unit test expectations with the revised behavior

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4b1c362d8832fb25d6a4ffd931547