### PR TITLE
Add logging for qpdf and lock route failures

### DIFF
--- a/backend/src/routes/docs.routes.ts
+++ b/backend/src/routes/docs.routes.ts
@@ -95,6 +95,11 @@ router.post('/lock', (req, res) => {
       return res.status(200).send(lockedBytes);
     } catch (error) {
       if (!responded) {
+        // eslint-disable-next-line no-console
+        console.error('Failed to lock document request', {
+          message: (error as Error).message,
+          stack: (error as Error).stack,
+        });
         await cleanup({ removeOutput: true });
         return res.status(500).json({ error: 'Unable to lock document' });
       }

--- a/backend/src/services/pdf.service.ts
+++ b/backend/src/services/pdf.service.ts
@@ -26,6 +26,12 @@ async function runQpdfEncryption(
     }
 
     qpdf.once('error', (error: Error) => {
+      // eslint-disable-next-line no-console
+      console.error('qpdf process error event', {
+        stderr: stderr.trim() || undefined,
+        stack: error.stack,
+        message: error.message,
+      });
       reject(error);
     });
 
@@ -37,6 +43,13 @@ async function runQpdfEncryption(
         const error = new Error(
           message ? `qpdf exited with code ${code}: ${message}` : `qpdf exited with code ${code}`,
         );
+        // eslint-disable-next-line no-console
+        console.error('qpdf process exited with non-zero code', {
+          code,
+          stderr: message || undefined,
+          stack: error.stack,
+          message: error.message,
+        });
         reject(error);
       }
     });


### PR DESCRIPTION
## Summary
- add console logging for qpdf process error and non-zero exit cases, including stderr output
- log unexpected errors in the lock document route before returning a server error

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d752dc501c832fa1be8f14e3d671fe