### PR TITLE
Update frontend rewrite to target new backend domain

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -2,7 +2,7 @@
   "rewrites": [
     {
       "source": "/api/(.*)",
-      "destination": "https://pdf-lock.vercel.app/api/$1"
+      "destination": "https://pdf-unlock-backend.vercel.app/api/$1"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- update the Vercel rewrite for API routes to target the pdf-unlock backend deployment

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_68d9e3ead788832fac7f18165a2951b7