### PR TITLE
Add production API fallback for frontend

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -14,7 +14,7 @@ By default the development server will proxy API calls to the backend target def
 
 ## Deployment notes
 
-The production site is deployed on Vercel. The `vercel.json` file configures rewrites so that requests to `/api/*` are forwarded to the backend deployment. Because Vercel rewrites happen at the edge, you must ensure that the destination host always resolves correctly.
+The production site is deployed on Vercel. The `vercel.json` file configures rewrites so that requests to `/api/*` are forwarded to the backend deployment. Because Vercel rewrites happen at the edge, you must ensure that the destination host always resolves correctly. When the `PDF_UNLOCK_BACKEND_HOST` or `VITE_API_BASE_URL` environment variables are not set, the frontend now falls back to `https://pdf-unlock-backend.vercel.app/api` so users can continue testing the locking flow while the configuration is repaired.
 
 When rolling out a new backend deployment, update the `PDF_UNLOCK_BACKEND_HOST` environment variable in the frontend project before shipping. This avoids a window where the rewrite points at an inactive host.
 

--- a/frontend/src/api/ApiProvider.tsx
+++ b/frontend/src/api/ApiProvider.tsx
@@ -1,6 +1,7 @@
 import type { FC, ReactNode } from 'react'
 import { useCallback, useMemo, useReducer } from 'react'
 import { createApiClient, type CreateApiClientOptions } from './client.js'
+import { resolveApiBaseUrl } from '../config/resolveApiBaseUrl.js'
 import { ApiContext, type ApiContextValue } from './context.js'
 import { apiStateReducer } from './state.js'
 
@@ -12,7 +13,7 @@ export type ApiProviderProps = {
 
 export const ApiProvider: FC<ApiProviderProps> = ({
   children,
-  baseUrl = '/api',
+  baseUrl = resolveApiBaseUrl(),
   withCredentials,
 }) => {
   const client = useMemo(

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,9 +9,14 @@ export const createApiClient = (
   options: CreateApiClientOptions = {},
 ): AxiosInstance => {
   const { baseUrl = '/api', withCredentials = false } = options
+  const sanitizedBaseUrl = baseUrl.trim()
+
+  if (!sanitizedBaseUrl) {
+    throw new Error('API client base URL cannot be empty. Check the frontend configuration.')
+  }
 
   return axios.create({
-    baseURL: baseUrl,
+    baseURL: sanitizedBaseUrl,
     headers: {
       Accept: 'application/json',
       'Content-Type': 'application/json',

--- a/frontend/src/config/resolveApiBaseUrl.ts
+++ b/frontend/src/config/resolveApiBaseUrl.ts
@@ -1,0 +1,88 @@
+const PRODUCTION_FALLBACK_API_BASE_URL = 'https://pdf-unlock-backend.vercel.app/api'
+const DEVELOPMENT_FALLBACK_API_BASE_URL = '/api'
+
+const trimTrailingSlashes = (value: string): string => value.replace(/\/+$/, '')
+
+const readEnvValue = (key: string): string | undefined => {
+  if (typeof import.meta !== 'undefined') {
+    const env = (import.meta as { env?: Record<string, unknown> }).env
+    if (env) {
+      const value = env[key]
+      if (typeof value === 'string') {
+        return value
+      }
+    }
+  }
+
+  if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+    const value = process.env[key]
+    if (typeof value === 'string') {
+      return value
+    }
+  }
+
+  return undefined
+}
+
+const sanitizeUrl = (value: string | undefined): string | null => {
+  if (!value) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) {
+    return null
+  }
+
+  return trimTrailingSlashes(trimmed)
+}
+
+const sanitizeHost = (host: string): string | null => {
+  if (!host) {
+    return null
+  }
+
+  const withoutProtocol = host.replace(/^https?:\/\//i, '')
+  const trimmed = withoutProtocol.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  return trimmed.replace(/\/+$/, '')
+}
+
+const isProductionEnvironment = (): boolean => {
+  if (typeof import.meta !== 'undefined' && typeof import.meta.env !== 'undefined') {
+    if (import.meta.env.PROD === true) {
+      return true
+    }
+  }
+
+  if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+    if (process.env.NODE_ENV === 'production') {
+      return true
+    }
+  }
+
+  return false
+}
+
+export const resolveApiBaseUrl = (): string => {
+  const explicitBaseUrl = sanitizeUrl(readEnvValue('VITE_API_BASE_URL'))
+  if (explicitBaseUrl) {
+    return explicitBaseUrl
+  }
+
+  const backendHost = sanitizeHost(readEnvValue('VITE_API_BACKEND_HOST') ?? readEnvValue('PDF_UNLOCK_BACKEND_HOST'))
+  if (backendHost) {
+    return `https://${backendHost}/api`
+  }
+
+  if (isProductionEnvironment()) {
+    return PRODUCTION_FALLBACK_API_BASE_URL
+  }
+
+  return DEVELOPMENT_FALLBACK_API_BASE_URL
+}
+

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,9 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App'
 import { ApiProvider } from './api'
+import { resolveApiBaseUrl } from './config/resolveApiBaseUrl.js'
 
-const apiBaseUrl = import.meta.env.VITE_API_BASE_URL ?? '/api'
+const apiBaseUrl = resolveApiBaseUrl()
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/tests/apiState.test.js
+++ b/frontend/tests/apiState.test.js
@@ -127,4 +127,11 @@ describe('createApiClient', () => {
     assert.equal(client.defaults.withCredentials, true)
     assert.equal(client.defaults.headers['Content-Type'], 'application/json')
   })
+
+  it('throws when provided an empty base URL', () => {
+    assert.throws(
+      () => createApiClient({ baseUrl: '   ' }),
+      /base url cannot be empty/i,
+    )
+  })
 })

--- a/frontend/tests/resolveApiBaseUrl.test.js
+++ b/frontend/tests/resolveApiBaseUrl.test.js
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict'
+import { after, beforeEach, describe, it } from 'node:test'
+
+const originalEnv = {
+  VITE_API_BASE_URL: process.env.VITE_API_BASE_URL,
+  VITE_API_BACKEND_HOST: process.env.VITE_API_BACKEND_HOST,
+  PDF_UNLOCK_BACKEND_HOST: process.env.PDF_UNLOCK_BACKEND_HOST,
+  NODE_ENV: process.env.NODE_ENV,
+}
+
+const setEnvValue = (key, value) => {
+  if (typeof value === 'undefined') {
+    delete process.env[key]
+    return
+  }
+
+  process.env[key] = value
+}
+
+const restoreOriginalEnv = () => {
+  setEnvValue('VITE_API_BASE_URL', originalEnv.VITE_API_BASE_URL)
+  setEnvValue('VITE_API_BACKEND_HOST', originalEnv.VITE_API_BACKEND_HOST)
+  setEnvValue('PDF_UNLOCK_BACKEND_HOST', originalEnv.PDF_UNLOCK_BACKEND_HOST)
+  setEnvValue('NODE_ENV', originalEnv.NODE_ENV)
+}
+
+const resetTestEnv = () => {
+  setEnvValue('VITE_API_BASE_URL', undefined)
+  setEnvValue('VITE_API_BACKEND_HOST', undefined)
+  setEnvValue('PDF_UNLOCK_BACKEND_HOST', undefined)
+  setEnvValue('NODE_ENV', undefined)
+}
+
+const loadResolver = async () => {
+  const module = await import('../dist-test/config/resolveApiBaseUrl.js')
+  return module.resolveApiBaseUrl
+}
+
+describe('resolveApiBaseUrl', () => {
+  beforeEach(() => {
+    restoreOriginalEnv()
+    resetTestEnv()
+  })
+
+  after(() => {
+    restoreOriginalEnv()
+  })
+
+  it('prefers an explicit VITE_API_BASE_URL when provided', async () => {
+    setEnvValue('VITE_API_BASE_URL', ' https://api.example.test/v1/ ')
+
+    const resolveApiBaseUrl = await loadResolver()
+
+    assert.equal(resolveApiBaseUrl(), 'https://api.example.test/v1')
+  })
+
+  it('builds a URL from the backend host environment variables', async () => {
+    setEnvValue('PDF_UNLOCK_BACKEND_HOST', 'custom-backend.vercel.app/')
+
+    const resolveApiBaseUrl = await loadResolver()
+
+    assert.equal(resolveApiBaseUrl(), 'https://custom-backend.vercel.app/api')
+  })
+
+  it('falls back to the production default when NODE_ENV is production', async () => {
+    setEnvValue('NODE_ENV', 'production')
+
+    const resolveApiBaseUrl = await loadResolver()
+
+    assert.equal(resolveApiBaseUrl(), 'https://pdf-unlock-backend.vercel.app/api')
+  })
+
+  it('uses the development proxy path by default', async () => {
+    const resolveApiBaseUrl = await loadResolver()
+
+    assert.equal(resolveApiBaseUrl(), '/api')
+  })
+})


### PR DESCRIPTION
## Summary
- add a runtime helper that resolves the API base URL with production and environment fallbacks
- default the ApiProvider and entrypoint to the resolved base URL and harden the axios client configuration
- document the new fallback behaviour and cover it with node:test suites

## Testing
- not run (QA environment)


------
https://chatgpt.com/codex/tasks/task_e_68d9fa1a86c8832fac3073455d421ccb